### PR TITLE
Make TaskLot a MongoModel

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,9 +1,9 @@
 version: 2
 ccu_store:
-  db_name: ropod_ccu_store
+  db_name: ccu_store
   port: 27017
 robot_store:
-  db_name: ropod_store
+  db_name: robot_store
   port: 27017
 resource_manager:
   resources:
@@ -87,7 +87,7 @@ api:
         - TASK-PROGRESS
         - BID
         - FINISH-ROUND
-        - ALLOCATE-TASK
+        - START-TEST
     acknowledge: false
     debug_messages:
       - 'TASK-REQUEST'
@@ -101,8 +101,8 @@ api:
         groups: ['TASK-ALLOCATION']
         method: shout
     callbacks:
-      - msg_type: 'ALLOCATE-TASK'
-        component: 'resource_manager.auctioneer.allocate_task_cb'
+      - msg_type: 'START-TEST'
+        component: 'resource_manager.auctioneer.start_test_cb'
       - msg_type: 'BID'
         component: 'resource_manager.auctioneer.bid_cb'
       - msg_type: 'FINISH-ROUND'

--- a/mrs/models/timetable.py
+++ b/mrs/models/timetable.py
@@ -1,0 +1,34 @@
+from pymodm import fields, MongoModel
+from pymongo.errors import ServerSelectionTimeoutError
+from fleet_management.utils.messages import Document
+import logging
+
+
+class Timetable(MongoModel):
+    robot_id = fields.CharField(primary_key=True)
+    zero_timepoint = fields.DateTimeField()
+    stn = fields.DictField()
+    dispatchable_graph = fields.DictField(default=dict())
+
+    class Meta:
+        archive_collection = 'timetable_archive'
+        ignore_unknown_fields = True
+
+    def save(self):
+        try:
+            super().save(cascade=True)
+        except ServerSelectionTimeoutError:
+            logging.warning('Could not save models to MongoDB')
+
+    @classmethod
+    def from_payload(cls, payload):
+        document = Document.from_msg(payload)
+        document['_id'] = document.pop('robot_id')
+        timetable = Timetable.from_document(document)
+        return timetable
+
+    def to_dict(self):
+        dict_repr = self.to_son().to_dict()
+        dict_repr.pop('_cls')
+        dict_repr["robot_id"] = str(dict_repr.pop('_id'))
+        return dict_repr

--- a/mrs/structs/allocation.py
+++ b/mrs/structs/allocation.py
@@ -1,48 +1,63 @@
+import logging
+
+from fleet_management.db.models.task import TaskConstraints, TimepointConstraints
+from fleet_management.utils.messages import Document
+from pymodm import fields, MongoModel
+from pymongo.errors import ServerSelectionTimeoutError
 from ropod.utils.timestamp import TimeStamp
 from ropod.utils.uuid import generate_uuid
-from fleet_management.db.models.task import TaskConstraints, TimepointConstraints
 
 
-class TaskLot:
-    def __init__(self, task_id,
-                 start_location,
-                 finish_location,
-                 earliest_start_time,
-                 latest_start_time,
-                 hard_constraints):
+class TaskLot(MongoModel):
+    task_id = fields.UUIDField(primary_key=True)
+    start_location = fields.CharField()
+    finish_location = fields.CharField()
+    constraints = fields.EmbeddedDocumentField(TaskConstraints)
 
-        self.task_id = str(task_id)
-        self.start_location = start_location
-        self.finish_location = finish_location
+    class Meta:
+        archive_collection = 'task_lot_archive'
+        ignore_unknown_fields = True
+
+    def save(self):
+        try:
+            super().save(cascade=True)
+        except ServerSelectionTimeoutError:
+            logging.warning('Could not save models to MongoDB')
+
+    @classmethod
+    def create(cls, task_id,
+               start_location,
+               finish_location,
+               earliest_start_time,
+               latest_start_time,
+               hard_constraints):
 
         start_timepoint_constraints = TimepointConstraints(earliest_time=earliest_start_time,
                                                            latest_time=latest_start_time)
-        time_point_constraints = [start_timepoint_constraints]
-        self.constraints = TaskConstraints(time_point_constraints=time_point_constraints,
-                                           hard=hard_constraints)
+        timepoint_constraints = [start_timepoint_constraints]
 
-    def to_dict(self):
-        dict_repr = dict()
-        dict_repr["task_id"] = self.task_id
-        dict_repr["start_location"] = self.start_location
-        dict_repr["finish_location"] = self.finish_location
-        dict_repr["constraints"] = self.constraints.to_dict()
+        constraints = TaskConstraints(timepoint_constraints=timepoint_constraints,
+                                      hard=hard_constraints)
 
-        return dict_repr
+        task_lot = cls(task_id, start_location, finish_location, constraints)
+        task_lot.save()
+
+        return task_lot
 
     @classmethod
-    def from_dict(cls, task_dict):
-        task_id = task_dict["task_id"]
-        start_location = task_dict["start_location"]
-        finish_location = task_dict["finish_location"]
-        constraints = TaskConstraints.from_payload(task_dict["constraints"])
+    def from_payload(cls, payload):
+        document = Document.from_msg(payload)
+        document['_id'] = document.pop('task_id')
+        document["constraints"] = TaskConstraints.from_payload(document.pop("constraints"))
+        task_lot = TaskLot.from_document(document)
+        return task_lot
 
-        start_timepoint_constraints = constraints.time_point_constraints[0]
-
-        task = cls(task_id, start_location, finish_location, start_timepoint_constraints.earliest_time,
-                   start_timepoint_constraints.latest_time, constraints.hard)
-
-        return task
+    def to_dict(self):
+        dict_repr = self.to_son().to_dict()
+        dict_repr.pop('_cls')
+        dict_repr["task_id"] = str(dict_repr.pop('_id'))
+        dict_repr["constraints"] = self.constraints.to_dict()
+        return dict_repr
 
     @classmethod
     def from_request(cls, task_id, request):
@@ -51,9 +66,9 @@ class TaskLot:
         earliest_start_time = request.earliest_pickup_time
         latest_start_time = request.latest_pickup_time
         hard_constraints = request.hard_constraints
-        task = cls(task_id, start_location, finish_location, earliest_start_time,
-                   latest_start_time, hard_constraints)
-        return task
+        task_lot = TaskLot.create(task_id, start_location, finish_location, earliest_start_time,
+                       latest_start_time, hard_constraints)
+        return task_lot
 
 
 class TaskAnnouncement(object):
@@ -81,7 +96,7 @@ class TaskAnnouncement(object):
         task_announcement_dict['tasks_lots'] = dict()
 
         for task_lot in self.tasks_lots:
-            task_announcement_dict['tasks_lots'][task_lot.task_id] = task_lot.to_dict()
+            task_announcement_dict['tasks_lots'][str(task_lot.task_id)] = task_lot.to_dict()
 
         task_announcement_dict['round_id'] = self.round_id
         task_announcement_dict['zero_timepoint'] = self.zero_timepoint.to_str()
@@ -97,7 +112,7 @@ class TaskAnnouncement(object):
         tasks_lots = list()
 
         for task_id, task_dict in tasks_dict.items():
-            tasks_lots.append(TaskLot.from_dict(task_dict))
+            tasks_lots.append(TaskLot.from_payload(task_dict))
 
         task_announcement = TaskAnnouncement(tasks_lots, round_id, zero_timepoint)
 

--- a/mrs/structs/allocation.py
+++ b/mrs/structs/allocation.py
@@ -5,7 +5,7 @@ from fleet_management.utils.messages import Document
 from pymodm import fields, MongoModel
 from pymongo.errors import ServerSelectionTimeoutError
 from ropod.utils.timestamp import TimeStamp
-from ropod.utils.uuid import generate_uuid
+from ropod.utils.uuid import generate_uuid, from_str
 
 
 class TaskLot(MongoModel):
@@ -105,7 +105,7 @@ class TaskAnnouncement(object):
 
     @staticmethod
     def from_dict(task_announcement_dict):
-        round_id = task_announcement_dict['round_id']
+        round_id = from_str(task_announcement_dict['round_id'])
         zero_timepoint = TimeStamp.from_str(task_announcement_dict['zero_timepoint'])
 
         tasks_dict = task_announcement_dict['tasks_lots']

--- a/mrs/structs/bid.py
+++ b/mrs/structs/bid.py
@@ -1,4 +1,5 @@
 import numpy as np
+from ropod.utils.uuid import from_str
 
 
 class Bid(object):
@@ -47,8 +48,8 @@ class Bid(object):
     @classmethod
     def from_dict(cls, bid_dict):
         robot_id = bid_dict['robot_id']
-        round_id = bid_dict['round_id']
-        task_id = bid_dict['task_id']
+        round_id = from_str(bid_dict['round_id'])
+        task_id = from_str(bid_dict['task_id'])
         position = bid_dict['position']
         risk_metric = bid_dict['risk_metric']
         temporal_metric = bid_dict['temporal_metric']

--- a/mrs/structs/task.py
+++ b/mrs/structs/task.py
@@ -1,7 +1,39 @@
+import logging
+
+from fleet_management.utils.messages import Document
 from pymodm import fields, MongoModel
+from pymongo.errors import ServerSelectionTimeoutError
 from ropod.utils.uuid import generate_uuid
 
 
 class Task(MongoModel):
     task_id = fields.UUIDField(primary_key=True, default=generate_uuid())
 
+    class Meta:
+        archive_collection = 'task_archive'
+        ignore_unknown_fields = True
+
+    def save(self):
+        try:
+            super().save(cascade=True)
+        except ServerSelectionTimeoutError:
+            logging.warning('Could not save models to MongoDB')
+
+    @classmethod
+    def create(cls, task_id):
+        task = cls(task_id)
+        task.save()
+        return task
+
+    @classmethod
+    def from_payload(cls, payload):
+        document = Document.from_msg(payload)
+        document['_id'] = document.pop('task_id')
+        task = Task.from_document(document)
+        return task
+
+    def to_dict(self):
+        dict_repr = self.to_son().to_dict()
+        dict_repr.pop('_cls')
+        dict_repr["task_id"] = str(dict_repr.pop('_id'))
+        return dict_repr

--- a/mrs/structs/timetable.py
+++ b/mrs/structs/timetable.py
@@ -76,7 +76,7 @@ class Timetable(object):
             task (obj): task object to be converted
             zero_timepoint (TimeStamp): Zero Time Point. Origin time to which task temporal information is referenced to
         """
-        start_timepoint_constraints = task.constraints.time_point_constraints[0]
+        start_timepoint_constraints = task.constraints.timepoint_constraints[0]
 
         r_earliest_start_time, r_latest_start_time = TimepointConstraints.relative_to_ztp(start_timepoint_constraints,
                                                                                           self.zero_timepoint)

--- a/mrs/structs/timetable.py
+++ b/mrs/structs/timetable.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from fleet_management.db.models.task import TimepointConstraints
 from ropod.utils.timestamp import TimeStamp
 from stn.task import STNTask
+from mrs.models.timetable import Timetable as TimetableMongo
 
 from mrs.exceptions.task_allocation import NoSTPSolution
 
@@ -212,4 +213,11 @@ class Timetable(object):
             timetable.schedule = schedule
 
         return timetable
+
+    def store(self):
+
+        timetable = TimetableMongo(self.robot_id, self.zero_timepoint.to_datetime(),
+                                   self.stn.to_dict(), self.dispatchable_graph.to_dict())
+        timetable.save()
+
 

--- a/mrs/task_allocation/auctioneer.py
+++ b/mrs/task_allocation/auctioneer.py
@@ -103,6 +103,7 @@ class Auctioneer(object):
             pass
 
         self.timetables.update({robot_id: timetable})
+        timetable.store()
 
         self.logger.debug("STN robot %s: %s", robot_id, timetable.stn)
         self.logger.debug("Dispatchable graph robot %s: %s", robot_id, timetable.dispatchable_graph)

--- a/mrs/task_allocation/auctioneer.py
+++ b/mrs/task_allocation/auctioneer.py
@@ -12,6 +12,8 @@ from mrs.structs.allocation import TaskAnnouncement, Allocation
 from mrs.structs.allocation import TaskLot
 from mrs.structs.timetable import Timetable
 from mrs.task_allocation.round import Round
+from fleet_management.db.models.task import TaskStatus
+from ropod.structs.task import TaskStatus as TaskStatusConst
 
 """ Implements a variation of the the TeSSI algorithm using the bidding_rule 
 specified in the config file
@@ -87,6 +89,8 @@ class Auctioneer(object):
         self.logger.debug("Tasks to allocate %s", self.tasks_to_allocate)
 
         self.logger.debug("Updating task status to ALLOCATED")
+        status = TaskStatus(task.task_id, TaskStatusConst.ALLOCATED)
+        status.save()
         self.update_timetable(robot_id, task, position)
 
         return allocation

--- a/mrs/task_allocation/auctioneer.py
+++ b/mrs/task_allocation/auctioneer.py
@@ -174,7 +174,6 @@ class Auctioneer(object):
 
     def get_task_schedule(self, task_id, robot_id):
         # For now, returning the start navigation time from the dispatchable graph
-        task_id = str(task_id)
         task_schedule = dict()
 
         timetable = self.timetables.get(robot_id)

--- a/mrs/task_allocation/auctioneer.py
+++ b/mrs/task_allocation/auctioneer.py
@@ -155,12 +155,9 @@ class Auctioneer(object):
         self.round.start()
         self.api.publish(msg, groups=['TASK-ALLOCATION'])
 
-    def allocate_task_cb(self, msg):
-        self.logger.debug("Task received")
-        task_cls = getattr(import_module('mrs.structs.allocation'), 'TaskLot')
-        task_dict = msg['payload']['task']
-        task = task_cls.from_dict(task_dict)
-        self.add_task(task)
+    def start_test_cb(self, msg):
+        self.logger.debug("Start test msg received")
+        # TODO Read tasks from ccu_store
 
     def bid_cb(self, msg):
         bid = msg['payload']
@@ -176,7 +173,7 @@ class Auctioneer(object):
 
     def get_task_schedule(self, task_id, robot_id):
         # For now, returning the start navigation time from the dispatchable graph
-
+        task_id = str(task_id)
         task_schedule = dict()
 
         timetable = self.timetables.get(robot_id)

--- a/mrs/task_allocation/round.py
+++ b/mrs/task_allocation/round.py
@@ -8,7 +8,6 @@ from mrs.exceptions.task_allocation import AlternativeTimeSlot
 from mrs.exceptions.task_allocation import NoAllocation
 from mrs.structs.bid import Bid
 import numpy as np
-import uuid
 
 
 class Round(object):
@@ -112,7 +111,7 @@ class Round(object):
 
         try:
             winning_bid = self.elect_winner()
-            allocated_task = self.tasks_to_allocate.pop(uuid.UUID(winning_bid.task_id), None)
+            allocated_task = self.tasks_to_allocate.pop(winning_bid.task_id, None)
             robot_id = winning_bid.robot_id
             position = winning_bid.position
             round_result = (allocated_task, robot_id, position, self.tasks_to_allocate)

--- a/mrs/task_allocation/round.py
+++ b/mrs/task_allocation/round.py
@@ -8,6 +8,7 @@ from mrs.exceptions.task_allocation import AlternativeTimeSlot
 from mrs.exceptions.task_allocation import NoAllocation
 from mrs.structs.bid import Bid
 import numpy as np
+import uuid
 
 
 class Round(object):
@@ -111,7 +112,7 @@ class Round(object):
 
         try:
             winning_bid = self.elect_winner()
-            allocated_task = self.tasks_to_allocate.pop(winning_bid.task_id, None)
+            allocated_task = self.tasks_to_allocate.pop(uuid.UUID(winning_bid.task_id), None)
             robot_id = winning_bid.robot_id
             position = winning_bid.position
             round_result = (allocated_task, robot_id, position, self.tasks_to_allocate)

--- a/mrs/utils/datasets.py
+++ b/mrs/utils/datasets.py
@@ -5,6 +5,7 @@ import yaml
 from ropod.utils.timestamp import TimeStamp
 
 from mrs.structs.allocation import TaskLot
+from mrs.structs.task import Task
 
 
 def load_yaml(file):
@@ -32,8 +33,12 @@ def load_yaml_dataset(dataset_path):
         earliest_start_time, latest_start_time = reference_to_current_time(task_info.get("earliest_start_time"),
                                                                            task_info.get("latest_start_time"))
         hard_constraints = task_info.get("hard_constraints")
-        tasks.append(TaskLot(task_id, start_location, finish_location,
-                             earliest_start_time, latest_start_time, hard_constraints))
+
+        TaskLot.create(task_id, start_location, finish_location, earliest_start_time, latest_start_time, hard_constraints)
+        task = Task.create(task_id)
+
+        tasks.append(task)
+
     return tasks
 
 


### PR DESCRIPTION
- task_lot: The task.task_id is an object of type uuid
- auctioneer: Remove allocate_task_cb and add start_test_cb.
- allocation_test: Stores tasks from the given dataset in mongo. Sends a START-TEST msg to the auctioneer
To do: When the Auctioneer receives a START-TEST msg, it should read the tasks from mongo and use them to fill the TASK-ANNOUNCEMENT msg