### PR TITLE
Tune round closure time

### DIFF
--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -13,10 +13,10 @@ experiment_store:
 
 fleet:
   - robot_001
-  - robot_002
-  - robot_003
-  - robot_004
-  - robot_005
+#  - robot_002
+#  - robot_003
+#  - robot_004
+#  - robot_005
 
 allocation_method: tessi-srea
 planner:
@@ -24,7 +24,7 @@ planner:
 
 ccu:
   auctioneer:
-    round_time: 15 # seconds
+    closure_window: 5 # seconds
     alternative_timeslots: True
   dispatcher:
     freeze_window: 5 # seconds

--- a/mrs/messages/task_announcement.py
+++ b/mrs/messages/task_announcement.py
@@ -2,6 +2,7 @@ from ropod.utils.timestamp import TimeStamp
 from ropod.utils.uuid import generate_uuid, from_str
 
 from mrs.db.models.task import Task
+from datetime import datetime
 
 
 class TaskAnnouncement(object):
@@ -23,6 +24,15 @@ class TaskAnnouncement(object):
             self.round_id = round_id
 
         self.zero_timepoint = zero_timepoint
+
+    def get_earliest_task(self):
+        earliest_time = datetime.max
+        for task in self.tasks:
+            timepoint_constraints = task.get_timepoint_constraints()
+            for constraint in timepoint_constraints:
+                if constraint.earliest_time < earliest_time:
+                    earliest_time = constraint.earliest_time
+        return earliest_time
 
     def to_dict(self):
         dict_repr = dict()

--- a/mrs/tests/fixtures/datasets/overlapping.yaml
+++ b/mrs/tests/fixtures/datasets/overlapping.yaml
@@ -12,9 +12,9 @@ task_type: task
 tasks:
   44c8caa6-ddf0-4876-8364-0c5ca8082880:
     delivery_location: C016-1
-    earliest_pickup_time: 1
+    earliest_pickup_time: 2
     hard_constraints: true
-    latest_pickup_time: 2
+    latest_pickup_time: 3
     pickup_location: C-stairs-2
     plan:
       estimated_duration: 78.18003969863874
@@ -35,9 +35,9 @@ tasks:
     task_id: 44c8caa6-ddf0-4876-8364-0c5ca8082880
   45b34703-eaaf-4063-b3cc-15acb7e850ca:
     delivery_location: C016-1
-    earliest_pickup_time: 4
+    earliest_pickup_time: 5
     hard_constraints: true
-    latest_pickup_time: 5
+    latest_pickup_time: 6
     pickup_location: C015
     plan:
       estimated_duration: 5.323976901616719


### PR DESCRIPTION
Close round some time (`closure_window` in config file) before the start of the earliest task in the TASK-ANNOUNCEMENT or as soon as a bid (or no-bid) from all robots is received
Closes #51