### PR TITLE
Process unsuccessful allocations with no alternative timeslots

### DIFF
--- a/mrs/exceptions/allocation.py
+++ b/mrs/exceptions/allocation.py
@@ -39,3 +39,9 @@ class InvalidAllocation(Exception):
         self.task_id = task_id
         self.robot_id = robot_id
         self.position = position
+
+
+class TaskNotFound(Exception):
+    def __init__(self, position):
+        """ Raised when attempting to read a task in a timetable position that does not exist"""
+        self.position = position

--- a/mrs/messages/task_announcement.py
+++ b/mrs/messages/task_announcement.py
@@ -42,36 +42,6 @@ class TaskAnnouncement(AsDictMixin):
         attrs.update(tasks=tasks)
         return attrs
 
-
-    # @classmethod
-    # def from_payload(cls, payload):
-    #     document = Document.from_payload(payload)
-    #     document.pop("metamodel")
-    #     tasks = list()
-    #     for task_id, task_dict in document.get("tasks").items():
-    #         tasks.append(Task.from_payload(task_dict))
-    #     document.update(tasks=tasks)
-    #     document.update(round_id=from_str(document["round_id"]))
-    #     document.update(zero_timepoint=TimeStamp.from_str(document["zero_timepoint"]))
-    #
-    #     print("----->Document")
-    #     print(document)
-    #     task_announcement = cls(**document)
-    #     return task_announcement
-
-        # round_id = from_str(payload['roundId'])
-        # zero_timepoint = TimeStamp.from_str(payload['zeroTimepoint'])
-        #
-        # tasks_dict = payload['tasks']
-        # tasks = list()
-        #[
-        # for task_id, task_dict in tasks_dict.items():
-        #     tasks.append(Task.from_payload(task_dict))
-        #
-        # task_announcement = TaskAnnouncement(tasks, round_id, zero_timepoint)
-        #
-        # return task_announcement
-
     @property
     def meta_model(self):
         return "task-announcement"

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -12,6 +12,7 @@ from stn.task import TimepointConstraint as STNTimepointConstraint
 from mrs.db.models.task import Task
 from mrs.db.models.task import TimepointConstraint
 from mrs.db.models.timetable import Timetable as TimetableMongo
+from mrs.exceptions.allocation import TaskNotFound
 
 logger = logging.getLogger("mrs.timetable")
 
@@ -168,6 +169,8 @@ class Timetable(object):
         task_id = self.stn.get_task_id(position)
         if task_id:
             return Task.get_task(task_id)
+        else:
+            raise TaskNotFound(position)
 
     def get_earliest_tasks(self, n_tasks=2):
         """ Returns a list of the earliest n_tasks in the timetable

--- a/mrs/utils/utils.py
+++ b/mrs/utils/utils.py
@@ -1,6 +1,7 @@
 from fmlib.utils.utils import load_file_from_module
 from fmlib.utils.utils import load_yaml
 import logging
+from datetime import datetime
 
 
 def load_yaml_file_from_module(module, file_name):
@@ -16,3 +17,11 @@ def load_yaml_file(file_name):
     with open(file_name, 'r') as file_handle:
         config = load_yaml(file_handle)
     return config
+
+
+def is_valid_time(time_):
+    """ Returns True if the given time_ is in the future,
+    False otherwise """
+    if time_ > datetime.now():
+        return True
+    return False


### PR DESCRIPTION
An unsuccessful allocation occurs when none of the robots can accommodate the task in its timetable without violating the temporal constraints. If no alternative timeslots are requested (config file), remove the task from the tasks_to_allocate. Also, remove the task if it is in the past (the temporal constraints are inconsistent) before opening an allocation round.

- task_announcement: Remove commented code
- exceptions/TaskNotFound: Raised when a timetable position does not exist
- utils: Add method to check if a given time is in the future (is valid)
- scheduling/monitor: Raise exception if task to schedule is not in dispatchable graph
- task: `get_earliest_task` returns task instead of earliest time
- Archive task if it cannot be allocated and `alternative_timeslots` is False: 
- Archive task if its earliest pickup time is in the past or if no bids were received for the task
- `update_tasks_to_allocate` rewrites the tasks_to_allocate (needed when tasks where archived)
- bidder: Do not compute bid for an insertion point  if the task in the previous insertion point was removed
- auctioneer: Process bids only if a bid is opened
- tests: Check db for unsuccessful allocations and keep track of allocations