### PR TITLE
Reject task contract if a task was removed during the round

### DIFF
--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -79,12 +79,7 @@ class CCU:
     def archive_task_cb(self, msg):
         payload = msg['payload']
         archive_task = ArchiveTask.from_payload(payload)
-        self.auctioneer.archive_task(archive_task.robot_id, archive_task.task_id, archive_task.node_id)
-
-        if self.auctioneer.round.opened:
-            self.logger.warning("Round %s has to be repeated", self.auctioneer.round.id)
-            self.auctioneer.round.finish()
-
+        self.auctioneer.archive_task(archive_task)
         self.dispatcher.timetable_manager.send_update_to = archive_task.robot_id
 
     def run(self):

--- a/mrs/messages/task_contract.py
+++ b/mrs/messages/task_contract.py
@@ -2,7 +2,7 @@ from mrs.utils.as_dict import AsDictMixin
 
 
 class TaskContract(AsDictMixin):
-    def __init__(self, task_id, robot_id, **kwargs):
+    def __init__(self, task_id, robot_id):
         self.task_id = task_id
         self.robot_id = robot_id
 
@@ -10,10 +10,18 @@ class TaskContract(AsDictMixin):
     def meta_model(self):
         return "task-contract"
 
+    @staticmethod
+    def is_valid(n_tasks_before, n_tasks_after):
+        if n_tasks_after - n_tasks_before == 1:
+            return True
+        return False
 
-class TaskContractAcknowledgment(AsDictMixin):
-    def __init__(self, robot_id):
-        self.robot_id = robot_id
+
+class TaskContractAcknowledgment(TaskContract):
+    def __init__(self, task_id, robot_id, n_tasks, accept=True):
+        super().__init__(task_id, robot_id)
+        self.accept = accept
+        self.n_tasks = n_tasks  # Number of tasks in the robot_id's stn, including task_id
 
     @property
     def meta_model(self):

--- a/mrs/robot.py
+++ b/mrs/robot.py
@@ -44,9 +44,7 @@ class Robot:
                 self.executor_interface.run()
                 # Provisional hack
                 if self.executor_interface.task_to_archive:
-                    self.bidder.archive_task(self.executor_interface.task_to_archive.robot_id,
-                                             self.executor_interface.task_to_archive.task_id,
-                                             self.executor_interface.task_to_archive.node_id)
+                    self.bidder.archive_task(self.executor_interface.task_to_archive)
                     self.executor_interface.task_to_archive = None
                 time.sleep(0.5)
         except (KeyboardInterrupt, SystemExit):


### PR DESCRIPTION
Repeat the round only if the winning bid was computed with an outdated timetable, i.e., the timetable contained more tasks at the beginning of the round than at the end. 

The auctioneer updates the timetable of the winning robot only if the robot accepts the task-contract and if no tasks have been removed between the task-contract shipment and task-contract-acknowledgment reception