### PR TITLE
Fix/bidder freeze task

### DIFF
--- a/mrs/allocation/bidder.py
+++ b/mrs/allocation/bidder.py
@@ -176,7 +176,7 @@ class Bidder:
         try:
             task = self.timetable.get_task(insertion_point)
             if task.frozen:
-                self.logger.debug("Task % is frozen. "
+                self.logger.debug("Task %s is frozen. "
                                   "Not computing bid for this insertion point %s", task.task_id, insertion_point)
                 return False
             return True

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -109,6 +109,7 @@ robot_proxy_api:
       groups:
         - TASK-ALLOCATION
       message_types: # Types of messages the node will listen to. Messages not listed will be ignored
+        - TASK
         - TASK-ANNOUNCEMENT
         - TASK-CONTRACT
         - ROBOT-POSE
@@ -144,6 +145,8 @@ robot_proxy_api:
         component: '.task_status_cb'
       - msg_type: 'RE-ALLOCATE'
         component: '.re_allocate_cb'
+      - msg_type: 'TASK'
+        component: '.task_cb'
 
 
 robot_api:

--- a/mrs/robot_proxy.py
+++ b/mrs/robot_proxy.py
@@ -22,6 +22,13 @@ class RobotProxy:
         self.api.register_callbacks(self)
         self.logger.info("Initialized Robot %s", robot_id)
 
+    def task_cb(self, msg):
+        payload = msg['payload']
+        task = Task.from_payload(payload)
+        self.logger.critical("Received task %s", task.task_id)
+        if self.robot_id in task.assigned_robots:
+            Task.freeze_task(task.task_id)
+
     def task_status_cb(self, msg):
         payload = msg['payload']
         task_status = TaskStatus.from_payload(payload)

--- a/mrs/tests/fixtures/datasets/overlapping.yaml
+++ b/mrs/tests/fixtures/datasets/overlapping.yaml
@@ -12,9 +12,9 @@ task_type: task
 tasks:
   44c8caa6-ddf0-4876-8364-0c5ca8082880:
     delivery_location: C016-1
-    earliest_pickup_time: 2
+    earliest_pickup_time: 3
     hard_constraints: true
-    latest_pickup_time: 3
+    latest_pickup_time: 4
     pickup_location: C-stairs-2
     plan:
       estimated_duration: 78.18003969863874


### PR DESCRIPTION
robot_proxy: Receives TASK msg and freezes task

Before, the robot_proxy was unaware of tasks frozen in the ccu. 