### PR TITLE
Add simpy real-time simulator

### DIFF
--- a/mrs/config/builder.py
+++ b/mrs/config/builder.py
@@ -1,20 +1,23 @@
 import logging
 
+from planner.planner import Planner
+from stn.stp import STP
+
 from mrs.allocation.auctioneer import Auctioneer
 from mrs.allocation.bidder import Bidder
 from mrs.dispatching.dispatcher import Dispatcher
 from mrs.execution.delay_recovery import DelayRecovery
 from mrs.execution.executor import Executor
 from mrs.execution.schedule_monitor import ScheduleMonitor
+from mrs.simulation.simulator import Simulator
 from mrs.timetable.timetable import Timetable
 from mrs.timetable.timetable_manager import TimetableManager
-from planner.planner import Planner
-from stn.stp import STP
 
 
 class MRTABuilder:
 
-    _component_modules = {'timetable': Timetable,
+    _component_modules = {'simulator': Simulator,
+                          'timetable': Timetable,
                           'timetable_manager': TimetableManager,
                           'planner': Planner,
                           'delay_recovery': DelayRecovery,
@@ -25,7 +28,8 @@ class MRTABuilder:
                           'schedule_monitor': ScheduleMonitor,
                           }
 
-    _config_order = ['timetable',
+    _config_order = ['simulator',
+                     'timetable',
                      'timetable_manager',
                      'planner',
                      'delay_recovery',

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -12,6 +12,10 @@ robot_store:
   db_name: robot_store
   port: 27017
 
+simulator:
+  initial_time: 2020-01-23T08:00:00.000000
+  factor: 0.05
+
 fleet:
   - robot_001
   - robot_002

--- a/mrs/db/models/task.py
+++ b/mrs/db/models/task.py
@@ -193,8 +193,7 @@ class Task(BaseTask):
                 if constraint.earliest_time < earliest_time:
                     earliest_time = constraint.earliest_time
                     earliest_task = task
-        if earliest_task:
-            return Task.get_task(earliest_task.task_id)
+        return earliest_task
 
     def remove(self):
         self.status.archive()

--- a/mrs/db/models/timetable.py
+++ b/mrs/db/models/timetable.py
@@ -19,7 +19,7 @@ TimetableManager = Manager.from_queryset(TimetableQuerySet)
 
 class Timetable(MongoModel):
     robot_id = fields.CharField(primary_key=True)
-    zero_timepoint = fields.DateTimeField()
+    ztp = fields.DateTimeField()
     stn = fields.DictField()
     dispatchable_graph = fields.DictField(default=dict())
 

--- a/mrs/dispatching/dispatcher.py
+++ b/mrs/dispatching/dispatcher.py
@@ -29,7 +29,7 @@ class Dispatcher(object):
 
         self.stp_solver = stp_solver
         self.timetable_manager = timetable_manager
-        self.schedule_monitor = ScheduleMonitor(self.timetable_manager, freeze_window)
+        self.schedule_monitor = ScheduleMonitor(self.timetable_manager, freeze_window, **kwargs)
 
         self.robot_ids = list()
 
@@ -53,13 +53,12 @@ class Dispatcher(object):
     def dispatch_tasks(self):
         for robot_id in self.robot_ids:
             timetable = self.timetable_manager.get_timetable(robot_id)
-            tasks = timetable.get_earliest_tasks()
-            for task in tasks:
-                if task.status.status == TaskStatusConst.PLANNED:
-                    start_time = timetable.get_start_time(task.task_id)
-                    if self.schedule_monitor.is_schedulable(start_time):
-                        Task.freeze_task(task.task_id)
-                        self.dispatch_task(task, robot_id)
+            task = timetable.get_earliest_task()
+            if task and task.status.status == TaskStatusConst.PLANNED:
+                start_time = timetable.get_start_time(task.task_id)
+                if self.schedule_monitor.is_schedulable(start_time):
+                    Task.freeze_task(task.task_id)
+                    self.dispatch_task(task, robot_id)
 
     def dispatch_task(self, task, robot_id):
         """

--- a/mrs/dispatching/schedule_monitor.py
+++ b/mrs/dispatching/schedule_monitor.py
@@ -1,11 +1,11 @@
 import logging
 from datetime import timedelta
 
-from ropod.utils.timestamp import TimeStamp
+from mrs.simulation.simulator import SimulatorInterface
 
 
-class ScheduleMonitor:
-    def __init__(self, timetable_manager, freeze_window):
+class ScheduleMonitor(SimulatorInterface):
+    def __init__(self, timetable_manager, freeze_window, **kwargs):
         """ Monitors the schedulability of tasks
 
         Args:
@@ -15,13 +15,16 @@ class ScheduleMonitor:
                         start navigation time is within the next 2 minutes.
 
         """
+        simulator = kwargs.get('simulator')
+        super().__init__(simulator)
+
         self.logger = logging.getLogger('mrs.schedule_monitor')
         self.timetable_manager = timetable_manager
         self.freeze_window = timedelta(seconds=freeze_window)
         self.logger.debug("Schedule Monitor started")
 
     def is_schedulable(self, start_time):
-        current_time = TimeStamp()
+        current_time = self.get_current_timestamp()
         if start_time.get_difference(current_time) < self.freeze_window:
             return True
         return False

--- a/mrs/execution/schedule_monitor.py
+++ b/mrs/execution/schedule_monitor.py
@@ -13,6 +13,7 @@ class ScheduleMonitor:
         self.logger = logging.getLogger('mrs.schedule.monitor.%s' % self.robot_id)
 
         self.timetable = timetable
+        self.timetable.fetch()
 
         self.recovery_method = delay_recovery.method
 

--- a/mrs/simulation/simulator.py
+++ b/mrs/simulation/simulator.py
@@ -1,0 +1,71 @@
+from datetime import datetime
+
+import simpy.rt
+from ropod.utils.timestamp import TimeStamp
+
+
+class Simulator:
+    def __init__(self, initial_time, factor=0.05, **kwargs):
+        """ Controls the simulation time
+
+        initial_time(datetime): Datetime object representing initial time
+        factor(float): Real time (in seconds) that passes between each simulation step
+                        e.g. with a factor of 0.05, a simulation step takes 0.05 seconds
+        """
+        self.env = simpy.rt.RealtimeEnvironment(initial_time=initial_time.timestamp(), factor=factor, strict=False)
+        self.current_time = initial_time
+
+    def get_current_time(self):
+        return self.current_time
+
+    def step(self):
+        self.current_time = datetime.fromtimestamp(self.env.now)
+        yield self.env.timeout(1)
+
+    def run(self):
+        proc = self.env.process(self.step())
+        self.env.run(until=proc)
+
+    def is_valid_time(self, time_):
+        """ Returns:
+            - True if the given time_ is in the future,
+            - False otherwise
+        """
+        if time_ > self.current_time:
+            return True
+        return False
+
+
+class SimulatorInterface:
+    def __init__(self, simulator):
+        self.simulator = simulator
+
+    def is_valid_time(self, time_):
+        if self.simulator is not None:
+            return self.simulator.is_valid_time(time_)
+        else:
+            if time_ > datetime.now():
+                return True
+            return False
+
+    def get_current_time(self):
+        if self.simulator is not None:
+            return self.simulator.get_current_time()
+        else:
+            return datetime.now()
+
+    def get_current_timestamp(self):
+        if self.simulator is not None:
+            return TimeStamp.from_datetime(self.simulator.get_current_time())
+        else:
+            return TimeStamp()
+
+    def init_ztp(self):
+        midnight = self.get_current_time().replace(hour=0, minute=0, second=0, microsecond=0)
+        ztp = TimeStamp()
+        ztp.timestamp = midnight
+        return ztp
+
+    def run(self):
+        if self.simulator is not None:
+            self.simulator.run()

--- a/mrs/tests/fixtures/datasets/overlapping.yaml
+++ b/mrs/tests/fixtures/datasets/overlapping.yaml
@@ -12,9 +12,9 @@ task_type: task
 tasks:
   44c8caa6-ddf0-4876-8364-0c5ca8082880:
     delivery_location: C016-1
-    earliest_pickup_time: 3
+    earliest_pickup_time: 10
     hard_constraints: true
-    latest_pickup_time: 4
+    latest_pickup_time: 20
     pickup_location: C-stairs-2
     plan:
       estimated_duration: 78.18003969863874
@@ -35,9 +35,9 @@ tasks:
     task_id: 44c8caa6-ddf0-4876-8364-0c5ca8082880
   45b34703-eaaf-4063-b3cc-15acb7e850ca:
     delivery_location: C016-1
-    earliest_pickup_time: 5
+    earliest_pickup_time: 22
     hard_constraints: true
-    latest_pickup_time: 6
+    latest_pickup_time: 25
     pickup_location: C015
     plan:
       estimated_duration: 5.323976901616719
@@ -48,9 +48,9 @@ tasks:
     task_id: 45b34703-eaaf-4063-b3cc-15acb7e850ca
   56f9df3b-5c64-4ab0-88d0-659023f121f2:
     delivery_location: C019
-    earliest_pickup_time: 7
+    earliest_pickup_time: 30
     hard_constraints: true
-    latest_pickup_time: 8
+    latest_pickup_time: 35
     pickup_location: C066
     plan:
       estimated_duration: 40.04105543597245
@@ -66,9 +66,9 @@ tasks:
     task_id: 56f9df3b-5c64-4ab0-88d0-659023f121f2
   8d1c137e-0bb0-4f6a-95e1-6246ce200a1a:
     delivery_location: C-stairs-2
-    earliest_pickup_time: 10
+    earliest_pickup_time: 40
     hard_constraints: true
-    latest_pickup_time: 11
+    latest_pickup_time: 45
     pickup_location: C019
     plan:
       estimated_duration: 76.63557847028359
@@ -92,9 +92,9 @@ tasks:
     task_id: 8d1c137e-0bb0-4f6a-95e1-6246ce200a1a
   a4a6c014-2be4-48b4-8ccc-2c5b1fff7ce1:
     delivery_location: C013-1
-    earliest_pickup_time: 13
+    earliest_pickup_time: 50
     hard_constraints: true
-    latest_pickup_time: 14
+    latest_pickup_time: 55
     pickup_location: C060
     plan:
       estimated_duration: 85.68859460016063

--- a/mrs/tests/fixtures/messages/start_test.json
+++ b/mrs/tests/fixtures/messages/start_test.json
@@ -1,0 +1,9 @@
+{
+  "header": {
+    "type": "START-TEST",
+    "metamodel": "ropod-msg-schema.json",
+    "msgId": ""
+  },
+  "payload": {
+  }
+}

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -1,6 +1,6 @@
 import copy
 import logging
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 from pymodm.errors import DoesNotExist
 from ropod.utils.timestamp import TimeStamp
@@ -15,11 +15,12 @@ from mrs.db.models.task import TimepointConstraint
 from mrs.db.models.timetable import Timetable as TimetableMongo
 from mrs.exceptions.allocation import TaskNotFound
 from mrs.exceptions.execution import InconsistentAssignment
+from mrs.simulation.simulator import SimulatorInterface
 
 logger = logging.getLogger("mrs.timetable")
 
 
-class Timetable(object):
+class Timetable(SimulatorInterface):
     """
     Each robot has a timetable, which contains temporal information about the robot's
     allocated tasks:
@@ -33,23 +34,19 @@ class Timetable(object):
     """
 
     def __init__(self, robot_id, stp_solver, **kwargs):
+        simulator = kwargs.get('simulator')
+        super().__init__(simulator)
+
         self.robot_id = robot_id
-        self.stp_solver = stp_solver  # Simple Temporal Problem
-        self.zero_timepoint = self.initialize_zero_timepoint()
+        self.stp_solver = stp_solver
+        self.ztp = self.init_ztp()
 
         self.stn = self.stp_solver.get_stn()
         self.dispatchable_graph = self.stp_solver.get_stn()
 
-    @staticmethod
-    def initialize_zero_timepoint():
-        today_midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
-        zero_timepoint = TimeStamp()
-        zero_timepoint.timestamp = today_midnight
-        return zero_timepoint
-
-    def update_zero_timepoint(self, time_):
-        self.zero_timepoint.timestamp = time_
-        logger.debug("Zero timepoint updated to: %s", self.zero_timepoint)
+    def update_ztp(self, time_):
+        self.ztp.timestamp = time_
+        logger.debug("Zero timepoint updated to: %s", self.ztp)
 
     def compute_dispatchable_graph(self, stn):
         try:
@@ -93,7 +90,7 @@ class Timetable(object):
 
         if not task.constraints.hard:
             if insertion_point == 1:
-                earliest_pickup_time = datetime.now() + timedelta(minutes=1)
+                earliest_pickup_time = self.get_current_time() + timedelta(minutes=1)
                 latest_pickup_time = earliest_pickup_time + pickup_time_window
                 soft_pickup_constraint = TimepointConstraint(name="pickup",
                                                              earliest_time=earliest_pickup_time,
@@ -105,8 +102,8 @@ class Timetable(object):
 
                 latest_pickup_time = earliest_pickup_time + pickup_time_window.total_seconds()
                 soft_pickup_constraint = TimepointConstraint(name="pickup",
-                                                             earliest_time=TimepointConstraint.absolute_time(self.zero_timepoint, earliest_pickup_time),
-                                                             latest_time=TimepointConstraint.absolute_time(self.zero_timepoint, latest_pickup_time))
+                                                             earliest_time=TimepointConstraint.absolute_time(self.ztp, earliest_pickup_time),
+                                                             latest_time=TimepointConstraint.absolute_time(self.ztp, latest_pickup_time))
             task.update_timepoint_constraint(**soft_pickup_constraint.to_dict())
 
     def previous_task_is_frozen(self, insertion_point):
@@ -124,7 +121,7 @@ class Timetable(object):
         pickup_constraint = task.get_timepoint_constraint("pickup")
         travel_time = task.get_inter_timepoint_constraint("travel_time")
         stn_start_constraint = self.stn.get_prev_timepoint_constraint("start",
-                                                                      STNTimepointConstraint(**pickup_constraint.to_dict_relative_to_ztp(self.zero_timepoint)),
+                                                                      STNTimepointConstraint(**pickup_constraint.to_dict_relative_to_ztp(self.ztp)),
                                                                       STNInterTimepointConstraint(**travel_time.to_dict()))
 
         if insertion_point > 1 and self.previous_task_is_frozen(insertion_point):
@@ -132,8 +129,8 @@ class Timetable(object):
             stn_start_constraint.r_earliest_time = max(stn_start_constraint.r_earliest_time,
                                                        r_latest_delivery_time_previous_task)
 
-        earliest_time = TimepointConstraint.absolute_time(self.zero_timepoint, stn_start_constraint.r_earliest_time)
-        latest_time = TimepointConstraint.absolute_time(self.zero_timepoint, stn_start_constraint.r_latest_time)
+        earliest_time = TimepointConstraint.absolute_time(self.ztp, stn_start_constraint.r_earliest_time)
+        latest_time = TimepointConstraint.absolute_time(self.ztp, stn_start_constraint.r_latest_time)
         start_constraint = TimepointConstraint(name="start",
                                                earliest_time=earliest_time,
                                                latest_time=latest_time)
@@ -144,10 +141,10 @@ class Timetable(object):
         pickup_constraint = task.get_timepoint_constraint("pickup")
         work_time = task.get_inter_timepoint_constraint("work_time")
         stn_delivery_constraint = self.stn.get_next_timepoint_constraint("delivery",
-                                                                         STNTimepointConstraint(**pickup_constraint.to_dict_relative_to_ztp(self.zero_timepoint)),
+                                                                         STNTimepointConstraint(**pickup_constraint.to_dict_relative_to_ztp(self.ztp)),
                                                                          STNInterTimepointConstraint(**work_time.to_dict()))
-        earliest_time = TimepointConstraint.absolute_time(self.zero_timepoint, stn_delivery_constraint.r_earliest_time)
-        latest_time = TimepointConstraint.absolute_time(self.zero_timepoint, stn_delivery_constraint.r_latest_time)
+        earliest_time = TimepointConstraint.absolute_time(self.ztp, stn_delivery_constraint.r_earliest_time)
+        latest_time = TimepointConstraint.absolute_time(self.ztp, stn_delivery_constraint.r_latest_time)
         delivery_constraint = TimepointConstraint(name="delivery",
                                                   earliest_time=earliest_time,
                                                   latest_time=latest_time)
@@ -159,7 +156,7 @@ class Timetable(object):
 
         timepoint_constraints = task.get_timepoint_constraints()
         for constraint in timepoint_constraints:
-            stn_timepoint_constraints.append(STNTimepointConstraint(**constraint.to_dict_relative_to_ztp(self.zero_timepoint)))
+            stn_timepoint_constraints.append(STNTimepointConstraint(**constraint.to_dict_relative_to_ztp(self.ztp)))
 
         inter_timepoint_constraints = task.get_inter_timepoint_constraints()
         for constraint in inter_timepoint_constraints:
@@ -209,20 +206,14 @@ class Timetable(object):
             return True
         return False
 
-    def get_earliest_tasks(self, n_tasks=1):
-        """ Returns a list of the earliest n_tasks in the timetable
-
-        :return: list of tasks
-        """
-        tasks = list()
-        for position in range(1, n_tasks+1):
-            task_id = self.stn.get_task_id(position)
-            if task_id:
-                try:
-                    tasks.append(Task.get_task(task_id))
-                except DoesNotExist:
-                    logging.warning("Task %s is not in db", task_id)
-        return tasks
+    def get_earliest_task(self):
+        task_id = self.stn.get_task_id(position=1)
+        if task_id:
+            try:
+                task = Task.get_task(task_id)
+                return task
+            except DoesNotExist:
+                logging.warning("Task %s is not in db", task_id)
 
     def get_r_time(self, task_id, node_type='start', lower_bound=True):
         r_time = self.dispatchable_graph.get_time(task_id, node_type, lower_bound)
@@ -230,17 +221,17 @@ class Timetable(object):
 
     def get_start_time(self, task_id):
         r_start_time = self.get_r_time(task_id)
-        start_time = self.zero_timepoint + timedelta(seconds=r_start_time)
+        start_time = self.ztp + timedelta(seconds=r_start_time)
         return start_time
 
     def get_pickup_time(self, task_id):
         r_pickup_time = self.get_r_time(task_id, 'pickup', False)
-        pickup_time = self.zero_timepoint + timedelta(seconds=r_pickup_time)
+        pickup_time = self.ztp + timedelta(seconds=r_pickup_time)
         return pickup_time
 
     def get_delivery_time(self, task_id):
         r_delivery_time = self.get_r_time(task_id, 'delivery', False)
-        delivery_time = self.zero_timepoint + timedelta(seconds=r_delivery_time)
+        delivery_time = self.ztp + timedelta(seconds=r_delivery_time)
         return delivery_time
 
     def remove_task(self, task_id):
@@ -277,7 +268,7 @@ class Timetable(object):
     def to_dict(self):
         timetable_dict = dict()
         timetable_dict['robot_id'] = self.robot_id
-        timetable_dict['zero_timepoint'] = self.zero_timepoint.to_str()
+        timetable_dict['ztp'] = self.ztp.to_str()
         timetable_dict['stn'] = self.stn.to_dict()
         timetable_dict['dispatchable_graph'] = self.dispatchable_graph.to_dict()
 
@@ -289,8 +280,8 @@ class Timetable(object):
         timetable = Timetable(robot_id, stp_solver)
         stn_cls = timetable.stp_solver.get_stn()
 
-        zero_timepoint = timetable_dict.get('zero_timepoint')
-        timetable.zero_timepoint = TimeStamp.from_str(zero_timepoint)
+        ztp = timetable_dict.get('ztp')
+        timetable.ztp = TimeStamp.from_str(ztp)
         timetable.stn = stn_cls.from_dict(timetable_dict['stn'])
         timetable.dispatchable_graph = stn_cls.from_dict(timetable_dict['dispatchable_graph'])
 
@@ -299,19 +290,20 @@ class Timetable(object):
     def store(self):
 
         timetable = TimetableMongo(self.robot_id,
-                                   self.zero_timepoint.to_datetime(),
+                                   self.ztp.to_datetime(),
                                    self.stn.to_dict(),
                                    self.dispatchable_graph.to_dict())
         timetable.save()
 
     def fetch(self):
         try:
+            logging.debug("Fetching timetable of robot %s", self.robot_id)
             timetable_mongo = TimetableMongo.objects.get_timetable(self.robot_id)
             self.stn = self.stn.from_dict(timetable_mongo.stn)
             self.dispatchable_graph = self.stn.from_dict(timetable_mongo.dispatchable_graph)
-            self.zero_timepoint = TimeStamp.from_datetime(timetable_mongo.zero_timepoint)
+            self.ztp = TimeStamp.from_datetime(timetable_mongo.ztp)
         except DoesNotExist:
-            # logging.debug("The timetable of robot %s is empty", self.robot_id)
+            logging.debug("The timetable of robot %s is empty", self.robot_id)
             # Resetting values
             self.stn = self.stp_solver.get_stn()
             self.dispatchable_graph = self.stp_solver.get_stn()

--- a/mrs/utils/datasets.py
+++ b/mrs/utils/datasets.py
@@ -1,26 +1,26 @@
 import collections
 from datetime import datetime, timedelta
 
-import dateutil.parser
 from fmlib.models.requests import TransportationRequest
+from ropod.utils.uuid import generate_uuid
+
 from mrs.db.models.task import Task
 from mrs.db.models.task import TimepointConstraint, TemporalConstraints
 from mrs.utils.utils import load_yaml_file_from_module
-from ropod.utils.uuid import generate_uuid
 
 
 def load_tasks_to_db(dataset_module, dataset_name, **kwargs):
     dataset_dict = load_yaml_file_from_module(dataset_module, dataset_name + '.yaml')
-    start_time = kwargs.get('start_time', datetime.now().isoformat())
+    initial_time = kwargs.get('initial_time', datetime.now())
 
     tasks_dict = dataset_dict.get('tasks')
     ordered_tasks = collections.OrderedDict(sorted(tasks_dict.items()))
     tasks = list()
 
     for task_id, task_info in ordered_tasks.items():
-        earliest_pickup_time, latest_pickup_time = reference_to_start_time(task_info.get("earliest_pickup_time"),
-                                                                           task_info.get("latest_pickup_time"),
-                                                                           start_time)
+        earliest_pickup_time, latest_pickup_time = reference_to_initial_time(task_info.get("earliest_pickup_time"),
+                                                                             task_info.get("latest_pickup_time"),
+                                                                             initial_time)
         request = TransportationRequest(request_id=generate_uuid(),
                                         pickup_location=task_info.get('pickup_location'),
                                         delivery_location=task_info.get('delivery_location'),
@@ -42,12 +42,9 @@ def load_tasks_to_db(dataset_module, dataset_name, **kwargs):
     return tasks
 
 
-def reference_to_start_time(earliest_time, latest_time, start_time_str=None):
-    start_time = dateutil.parser.parse(start_time_str)
-
-    r_earliest_time = start_time + timedelta(minutes=earliest_time)
-    r_latest_time = start_time + timedelta(minutes=latest_time)
-
+def reference_to_initial_time(earliest_time, latest_time, initial_time):
+    r_earliest_time = initial_time + timedelta(minutes=earliest_time)
+    r_latest_time = initial_time + timedelta(minutes=latest_time)
     return r_earliest_time, r_latest_time
 
 

--- a/mrs/utils/utils.py
+++ b/mrs/utils/utils.py
@@ -1,7 +1,7 @@
+import logging
+
 from fmlib.utils.utils import load_file_from_module
 from fmlib.utils.utils import load_yaml
-import logging
-from datetime import datetime
 
 
 def load_yaml_file_from_module(module, file_name):
@@ -17,11 +17,3 @@ def load_yaml_file(file_name):
     with open(file_name, 'r') as file_handle:
         config = load_yaml(file_handle)
     return config
-
-
-def is_valid_time(time_):
-    """ Returns True if the given time_ is in the future,
-    False otherwise """
-    if time_ > datetime.now():
-        return True
-    return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 numpy
 pymodm
 importlib_resources
+simpy
 git+https://github.com/anenriquez/fmlib.git@fix/remove-rospy-msg-converter
 git+https://github.com/anenriquez/mrta_stn.git@develop#egg=stn


### PR DESCRIPTION
Uses [simpy](https://simpy.readthedocs.io/en/latest/index.html)
A simulation step takes 0.05 seconds
Fetch timetables at startup (not at each allocation round)