### PR TITLE
Add conditions to repeat an allocation round

### DIFF
--- a/mrs/robot_proxy.py
+++ b/mrs/robot_proxy.py
@@ -75,6 +75,7 @@ class RobotProxy:
             start_node, finish_node = action.get_node_names()
             self.timetable.update_timetable(task.task_id, start_node, finish_node,
                                             action_progress.r_start_time, action_progress.r_finish_time)
+            self.bidder.changed_timetable = True
 
             self.logger.debug("Updated stn: \n %s ", self.timetable.stn)
             self.logger.debug("Updated dispatchable graph: \n %s", self.timetable.dispatchable_graph)
@@ -100,7 +101,7 @@ class RobotProxy:
     def _remove_task(self, task, status):
         self.logger.critical("Deleting task %s from timetable and changing its status to %s", task.task_id, status)
         self.timetable.remove_task(task.task_id)
-        self.bidder.deleted_a_task = True
+        self.bidder.changed_timetable = True
         task.update_status(status)
         self.logger.debug("STN: %s", self.timetable.stn)
         self.logger.debug("Dispatchable graph: %s", self.timetable.dispatchable_graph)

--- a/mrs/timetable/stn_interface.py
+++ b/mrs/timetable/stn_interface.py
@@ -23,6 +23,7 @@ class STNInterface:
 
     def update_task(self, stn_task):
         self.stn.update_task(stn_task)
+        self.dispatchable_graph.update_task(stn_task)
 
     def to_stn_task(self, task, insertion_point):
         self.update_pickup_constraint(task, insertion_point)


### PR DESCRIPTION
- Undo allocation if the timetable changed between task_contract and task_contrack_acknowledgement and repeat the round. 
If the timetable changed between task_contract announcement and task_contrack_acknowledgement reception, the auctioneer rejects the contract and the bidder undoes its last allocation.

- Repeat a round whenever the timetable of the winner robot changed while the round was opened. This includes changes due to task progress updates and recomputation of the dispatchable graph. 