### PR TITLE
Add PerformanceTracker

### DIFF
--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -164,17 +164,17 @@ class Auctioneer(SimulatorInterface):
             self.tasks_to_allocate.pop(earliest_task.task_id)
             return
 
+        self.changed_timetable.clear()
+        for task in tasks:
+            if not task.constraints.hard:
+                self.update_soft_constraints(task)
+
         self.round = Round(self.robot_ids,
                            self.tasks_to_allocate,
                            n_tasks=len(tasks),
                            closure_time=closure_time,
                            alternative_timeslots=self.alternative_timeslots,
                            simulator=self.simulator)
-
-        self.changed_timetable.clear()
-        for task in tasks:
-            if not task.constraints.hard:
-                self.update_soft_constraints(task)
 
         task_announcement = TaskAnnouncement(tasks, self.round.id, self.timetable_manager.ztp)
 

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -1,13 +1,13 @@
 import copy
 import logging
 import time
-
-from ropod.utils.uuid import generate_uuid
+from datetime import datetime
 
 from mrs.exceptions.allocation import AlternativeTimeSlot
 from mrs.exceptions.allocation import NoAllocation
 from mrs.messages.bid import SoftBid, NoBid, BiddingRobot
 from mrs.simulation.simulator import SimulatorInterface
+from ropod.utils.uuid import generate_uuid
 
 
 class Round(SimulatorInterface):
@@ -30,7 +30,7 @@ class Round(SimulatorInterface):
         self.received_bids = dict()
         self.received_no_bids = dict()
         self.bidding_robots = {robot_id: BiddingRobot(robot_id) for robot_id in self.robot_ids}
-        self.start_time = self.get_current_time().timestamp()
+        self.start_time = datetime.now().timestamp()
         self.time_to_allocate = None
 
     def start(self):
@@ -174,4 +174,7 @@ class Round(SimulatorInterface):
             raise NoAllocation(self.id, self.tasks_to_allocate)
 
         return lowest_bid
+
+    def get_time_to_allocate(self):
+        return self.time_to_allocate
 

--- a/mrs/config/builder.py
+++ b/mrs/config/builder.py
@@ -6,6 +6,7 @@ from mrs.dispatching.dispatcher import Dispatcher
 from mrs.execution.delay_recovery import DelayRecovery
 from mrs.execution.executor import Executor
 from mrs.execution.schedule_monitor import ScheduleMonitor
+from mrs.performance.tracker import PerformanceTracker
 from mrs.simulation.simulator import Simulator
 from mrs.timetable.timetable import Timetable
 from mrs.timetable.timetable_manager import TimetableManager
@@ -27,6 +28,7 @@ class MRTABuilder:
                           'executor': Executor,
                           'schedule_monitor': ScheduleMonitor,
                           'timetable_monitor': TimetableMonitor,
+                          'performance_tracker': PerformanceTracker,
                           }
 
     _config_order = ['simulator',
@@ -40,6 +42,7 @@ class MRTABuilder:
                      'executor',
                      'schedule_monitor',
                      'timetable_monitor',
+                     'performance_tracker',
                      ]
 
     """ Maps an allocation method to its stp_solver solver """

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -114,6 +114,8 @@ ccu_api:
         component: 'timetable_monitor.task_progress_cb'
       - msg_type: 'RE-ALLOCATE'
         component: 'timetable_monitor.re_allocate_cb'
+      - msg_type: 'RE-ALLOCATE'
+        component: 'performance_tracker.re_allocate_cb'
       - msg_type: 'ABORT'
         component: 'timetable_monitor.abort_cb'
       - msg_type: 'RE-SCHEDULE'

--- a/mrs/db/models/actions.py
+++ b/mrs/db/models/actions.py
@@ -1,7 +1,9 @@
+from fmlib.models.actions import ActionProgress as ActionProgressBase
 from fmlib.models.actions import GoTo as Action
 from fmlib.utils.messages import Document
-from mrs.db.models.task import InterTimepointConstraint
 from pymodm import fields
+
+from mrs.db.models.task import InterTimepointConstraint
 
 
 class GoTo(Action):
@@ -27,4 +29,38 @@ class GoTo(Action):
         dict_repr = self.to_son().to_dict()
         dict_repr.pop('_cls')
         dict_repr["estimated_duration"] = self.estimated_duration.to_dict()
+        return dict_repr
+
+
+class ActionProgress(ActionProgressBase):
+    r_start_time = fields.FloatField()
+    r_finish_time = fields.FloatField()
+    is_consistent = fields.BooleanField(default=True)
+
+    class Meta:
+        ignore_unknown_fields = True
+
+    def __str__(self):
+        return "action id: {}, action status: {}, start time: {}, finish time: {}".format(self.action.action_id,
+                                                                                          self.status,
+                                                                                          self.start_time,
+                                                                                          self.finish_time)
+
+    def update(self, status, abs_time, r_time):
+        self.status = status
+        if self.start_time:
+            self.finish_time = abs_time
+            self.r_finish_time = r_time
+        else:
+            self.start_time = abs_time
+            self.r_start_time = r_time
+
+    @classmethod
+    def from_payload(cls, payload):
+        document = Document.from_payload(payload)
+        return cls.from_document(document)
+
+    def to_dict(self):
+        dict_repr = self.to_son().to_dict()
+        dict_repr.pop('_cls')
         return dict_repr

--- a/mrs/db/models/performance/robot.py
+++ b/mrs/db/models/performance/robot.py
@@ -1,0 +1,62 @@
+from fmlib.models.robot import RobotManager as RobotPerformanceManager
+from pymodm import fields, MongoModel
+
+
+class RobotPerformance(MongoModel):
+    """ Stores robot performance information:
+    Metrics are computed based on the completed tasks
+
+    robot_id (str):  Identifies the robot
+
+    completion_time (float): Difference between the start of the first task and the finish time of the last task
+
+    makespan (datetime): Finish time of the last task
+
+    travel_time (float): Time taken to travel to task locations
+
+    work_time (float):  Time taken to perform all allocated tasks.
+
+    idle_time (float): Time robots are idle (waiting) to start their next allocated task
+
+    """
+    robot_id = fields.CharField(primary_key=True)
+    completion_time = fields.FloatField(default=0.0)
+    makespan = fields.DateTimeField()
+    travel_time = fields.FloatField(default=0.0)
+    work_time = fields.FloatField(default=0.0)
+    idle_time = fields.FloatField(default=0.0)
+
+    objects = RobotPerformanceManager()
+
+    class Meta:
+        ignore_unknown_fields = True
+
+    @classmethod
+    def create_new(cls, robot_id):
+        performance = cls(robot_id=robot_id)
+        performance.save()
+        return performance
+
+    def update_travel_time(self, travel_time):
+        self.travel_time += travel_time
+        self.save()
+
+    def update_work_time(self, work_time):
+        self.work_time += work_time
+        self.save()
+
+    def update_idle_time(self, idle_time):
+        self.idle_time += idle_time
+        self.save()
+
+    def update_completion_time(self, completion_time):
+        self.completion_time = completion_time
+        self.save()
+
+    def update_makespan(self, makespan):
+        self.makespan = makespan
+        self.save()
+
+    @classmethod
+    def get_robot_performance(cls, robot_id):
+        return cls.objects.get_robot(robot_id)

--- a/mrs/db/models/performance/task.py
+++ b/mrs/db/models/performance/task.py
@@ -1,0 +1,118 @@
+from fmlib.models.tasks import TaskManager as TaskPerformanceManager
+from fmlib.utils.messages import Document
+from mrs.db.models.task import Task
+from pymodm import fields, EmbeddedMongoModel, MongoModel
+
+
+class TaskAllocationPerformance(EmbeddedMongoModel):
+    """ Task performance metrics related to allocation
+
+    time_to_allocate (float): Time taken to allocate the task
+
+    n_previously_allocated_tasks (int): Number of task in the robot's STN before allocating this task
+
+    travel_time_boundaries ([float, float]): [min, max]
+                                           Travel time constraint boundaries in the d-graph, i.e.,
+                                           minimum and maximum time to start and complete the
+                                           ROBOT-TO-PICKUP action
+
+    work_time_boundaries ([float, float]): [min, max]
+                                       Work time constraint boundaries in the d-graph, i.e.,
+                                       minimum and maximum time to start and complete the
+                                       PICKUP-TO-DELIVERY action
+    """
+    time_to_allocate = fields.FloatField()
+    n_previously_allocated_tasks = fields.IntegerField()
+    travel_time_boundaries = fields.ListField()
+    work_time_boundaries = fields.ListField()
+    n_re_allocation_attempts = fields.IntegerField(default=0)
+
+    def update(self, **kwargs):
+        if 'time_to_allocate' in kwargs:
+            self.time_to_allocate = kwargs['time_to_allocate']
+        if 'n_previously_allocated_tasks' in kwargs:
+            self.n_previously_allocated_tasks = kwargs['n_previously_allocated_tasks']
+        if 'travel_time_boundaries' in kwargs:
+            self.travel_time_boundaries = kwargs['travel_time_boundaries']
+        if 'work_time_boundaries' in kwargs:
+            self.work_time_boundaries = kwargs['work_time_boundaries']
+
+
+class TaskExecutionPerformance(EmbeddedMongoModel):
+    """ Task performance metrics related to execution
+
+    travel_time (float): Time taken to reach the task location, i.e,
+                        Time to go from current position to pickup location
+
+    work_time (float):  Time taken to perform the task. i.e,
+                        Time to transport an object from the pickup to the delivery location
+
+    """
+    travel_time = fields.FloatField()
+    work_time = fields.FloatField()
+
+    def update(self, travel_time, work_time):
+        self.travel_time = travel_time
+        self.work_time = work_time
+
+
+class TaskPerformance(MongoModel):
+    """ Stores task performance information:
+
+    task (Task): Reference to Task object
+    allocation (TaskAllocationPerformance):  Task performance metrics related to allocation
+    execution (TaskExecutionPerformance):  Task performance metrics related to execution
+
+    """
+    task = fields.ReferenceField(Task, primary_key=True, required=True)
+    allocation = fields.EmbeddedDocumentField(TaskAllocationPerformance)
+    execution = fields.EmbeddedDocumentField(TaskExecutionPerformance)
+
+    objects = TaskPerformanceManager()
+
+    class Meta:
+        ignore_unknown_fields = True
+        meta_model = "task-performance"
+
+    @classmethod
+    def create_new(cls, task):
+        performance = cls(task=task)
+        performance.save()
+        return performance
+
+    def update_allocation(self, **kwargs):
+        if not self.allocation:
+            self.allocation = TaskAllocationPerformance()
+        self.allocation.update(**kwargs)
+        self.save(cascade=True)
+
+    def update_execution(self, travel_time, work_time):
+        if not self.execution:
+            self.execution = TaskExecutionPerformance()
+        self.execution.update(travel_time, work_time)
+        self.save(cascade=True)
+
+    def increase_n_re_allocation_attempts(self):
+        self.allocation.n_re_allocation_attempts += 1
+        self.save(cascade=True)
+
+    @classmethod
+    def from_payload(cls, payload):
+        document = Document.from_payload(payload)
+        document['_id'] = document.pop('task_id')
+        performance = TaskPerformance.from_document(document)
+        return performance
+
+    def to_dict(self):
+        dict_repr = self.to_son().to_dict()
+        dict_repr.pop('_cls')
+        dict_repr["task_id"] = str(dict_repr.pop('_id'))
+        return dict_repr
+
+    @classmethod
+    def get_task_performance(cls, task_id):
+        return cls.objects.get_task(task_id)
+
+    @property
+    def meta_model(self):
+        return self.Meta.meta_model

--- a/mrs/db/models/task.py
+++ b/mrs/db/models/task.py
@@ -246,8 +246,11 @@ class Task(BaseTask):
 
     @classmethod
     def get_task(cls, task_id):
-        with switch_connection(Task, "default"):
-            return cls.objects.get_task(task_id)
+        return cls.objects.get_task(task_id)
+
+    @classmethod
+    def get_tasks_by_robot(cls, robot_id):
+        return [task for task in cls.objects.all() if robot_id in task.assigned_robots]
 
     def archive(self):
         try:

--- a/mrs/messages/task_progress.py
+++ b/mrs/messages/task_progress.py
@@ -1,31 +1,5 @@
+from mrs.db.models.actions import ActionProgress
 from mrs.utils.as_dict import AsDictMixin
-from ropod.structs.status import ActionStatus
-
-
-class ActionProgress(AsDictMixin):
-    def __init__(self, action_id, **kwargs):
-        self.action_id = action_id
-        self.status = kwargs.get("status", ActionStatus.PLANNED)
-        self.start_time = kwargs.get("start_time")
-        self.finish_time = kwargs.get("finish_time")
-        self.r_start_time = kwargs.get("r_start_time")
-        self.r_finish_time = kwargs.get("r_finish_time")
-        self.is_consistent = kwargs.get("is_consistent", True)
-
-    def __str__(self):
-        return "action id: {}, action status: {}, start time: {}, finish time: {}".format(self.action_id,
-                                                                                          self.status,
-                                                                                          self.start_time,
-                                                                                          self.finish_time)
-
-    def update(self, status, abs_time, r_time):
-        self.status = status
-        if self.start_time:
-            self.finish_time = abs_time
-            self.r_finish_time = r_time
-        else:
-            self.start_time = abs_time
-            self.r_start_time = r_time
 
 
 class TaskProgress(AsDictMixin):
@@ -45,5 +19,5 @@ class TaskProgress(AsDictMixin):
     @classmethod
     def to_attrs(cls, dict_repr):
         attrs = super().to_attrs(dict_repr)
-        attrs.update(action_progress=ActionProgress.from_dict(attrs.get("action_progress")))
+        attrs.update(action_progress=ActionProgress.from_payload(attrs.get("action_progress")))
         return attrs

--- a/mrs/performance/robot.py
+++ b/mrs/performance/robot.py
@@ -1,0 +1,46 @@
+import logging
+
+from mrs.db.models.performance.robot import RobotPerformance
+from mrs.db.models.task import Task
+from pymodm.context_managers import switch_collection
+
+
+class RobotPerformanceTracker:
+    def __init__(self):
+        self.logger = logging.getLogger("mrs.performance.robot.tracker")
+        self.processed_tasks = list()
+
+    def update_metrics(self, robot_id, tasks_progress):
+        self.logger.debug("Updating performance of robot %s", robot_id)
+        robot_performance = RobotPerformance.get_robot_performance(robot_id)
+        for task_idx, actions_progress in enumerate(tasks_progress):
+            task_id = actions_progress[0].action.task_id
+            if task_id not in self.processed_tasks:
+                for action_progress in actions_progress:
+                    time_ = (action_progress.finish_time - action_progress.start_time).total_seconds()
+                    if action_progress.action.type == "ROBOT-TO-PICKUP":
+                        robot_performance.update_travel_time(time_)
+
+                        if task_idx > 0:
+                            prev_delivery_time = tasks_progress[task_idx-1][-1].finish_time
+                            start_time = tasks_progress[task_idx][0].start_time
+                            idle_time = (start_time - prev_delivery_time).total_seconds()
+                            robot_performance.update_idle_time(idle_time)
+
+                    elif action_progress.action.type == "PICKUP-TO-DELIVERY":
+                        robot_performance.update_work_time(time_)
+
+                self.processed_tasks.append(task_id)
+
+        start_first_task, finish_last_task = self.get_start_finish_times(tasks_progress)
+        completion_time = (finish_last_task - start_first_task).total_seconds()
+
+        robot_performance.update_completion_time(completion_time)
+        robot_performance.update_makespan(finish_last_task)
+
+    @staticmethod
+    def get_start_finish_times(tasks_progress):
+        finish_last_task = tasks_progress[-1][-1].finish_time
+        start_fist_task = tasks_progress[0][0].start_time
+        return start_fist_task, finish_last_task
+

--- a/mrs/performance/task.py
+++ b/mrs/performance/task.py
@@ -1,0 +1,58 @@
+import logging
+
+from fmlib.models.tasks import TaskStatus
+from mrs.db.models.performance.task import TaskPerformance
+from mrs.db.models.task import Task
+from pymodm.context_managers import switch_collection
+
+
+class TaskPerformanceTracker:
+    def __init__(self, auctioneer):
+        self.auctioneer = auctioneer
+        self.logger = logging.getLogger("mrs.performance.task.tracker")
+
+    def update_allocation_metrics(self, allocated_task_id, timetable, tasks_to_update):
+        for task_id in tasks_to_update:
+            task_performance = TaskPerformance.get_task_performance(task_id)
+            metrics = self.get_allocation_metrics(task_id, timetable)
+            if task_id == allocated_task_id:
+                task_performance.update_allocation(**metrics)
+            else:
+                task_performance.update_allocation(travel_time_boundaries=metrics.get("travel_time_boundaries"),
+                                                   work_time_boundaries=metrics.get("work_time_boundaries"))
+
+    def get_allocation_metrics(self, task_id, timetable):
+        time_to_allocate = self.auctioneer.round.get_time_to_allocate()
+        n_previously_allocated_tasks = len(timetable.get_tasks()) - 1
+
+        earliest_start_time = timetable.get_r_time(task_id, "start", lower_bound=True)
+        earliest_pickup_time = timetable.get_r_time(task_id, "pickup", lower_bound=True)
+        latest_pickup_time = timetable.get_r_time(task_id, "pickup", lower_bound=False)
+        earliest_delivery_time = timetable.get_r_time(task_id, "delivery", lower_bound=True)
+        latest_delivery_time = timetable.get_r_time(task_id, "delivery", lower_bound=False)
+
+        travel_time_boundaries = [earliest_pickup_time - earliest_start_time, latest_pickup_time - earliest_start_time]
+        work_time_boundaries = [earliest_delivery_time - earliest_pickup_time, latest_delivery_time - earliest_pickup_time]
+
+        return {'time_to_allocate': time_to_allocate,
+                'n_previously_allocated_tasks': n_previously_allocated_tasks,
+                'travel_time_boundaries': travel_time_boundaries,
+                'work_time_boundaries': work_time_boundaries}
+
+    def update_execution_metrics(self, task):
+        self.logger.debug("Updating execution metrics of task %s", task.task_id)
+        with switch_collection(TaskStatus, TaskStatus.Meta.archive_collection):
+            task_status = TaskStatus.objects.get({"_id": task.task_id})
+            travel_action = task_status.progress.actions[0]
+            work_action = task_status.progress.actions[1]
+            travel_time = (travel_action.finish_time - travel_action.start_time).total_seconds()
+            work_time = (work_action.finish_time - work_action.start_time).total_seconds()
+
+        with switch_collection(Task, Task.Meta.archive_collection):
+            task_performance = TaskPerformance.get_task_performance(task.task_id)
+            task_performance.update_execution(travel_time, work_time)
+
+    @staticmethod
+    def update_re_allocations(task_id):
+        task_performance = TaskPerformance.get_task_performance(task_id)
+        task_performance.increase_n_re_allocation_attempts()

--- a/mrs/performance/tracker.py
+++ b/mrs/performance/tracker.py
@@ -1,0 +1,50 @@
+import logging
+
+from fmlib.models.tasks import TaskStatus
+from mrs.db.models.task import Task
+from mrs.messages.recover import ReAllocate
+from mrs.performance.robot import RobotPerformanceTracker
+from mrs.performance.task import TaskPerformanceTracker
+from pymodm.context_managers import switch_collection
+
+
+class PerformanceTracker:
+    def __init__(self, auctioneer, timetable_manager, timetable_monitor, **kwargs):
+        self.auctioneer = auctioneer
+        self.timetable_manager = timetable_manager
+        self.timetable_monitor = timetable_monitor
+
+        self.task_performance_tracker = TaskPerformanceTracker(auctioneer)
+        self.robot_performance_tracker = RobotPerformanceTracker()
+
+        self.logger = logging.getLogger("mrs.performance.tracker")
+
+    def re_allocate_cb(self, msg):
+        payload = msg['payload']
+        recover = ReAllocate.from_payload(payload)
+        self.task_performance_tracker.update_re_allocations(recover.task_id)
+
+    def update_task_allocation_metrics(self, allocated_task_id, robot_ids, tasks_to_update):
+        for robot_id in robot_ids:
+            timetable = self.timetable_manager.get_timetable(robot_id)
+            self.task_performance_tracker.update_allocation_metrics(allocated_task_id, timetable, tasks_to_update)
+
+    @staticmethod
+    def get_tasks_progress(robot_id):
+        tasks_progress = list()
+        with switch_collection(Task, Task.Meta.archive_collection):
+            with switch_collection(TaskStatus, TaskStatus.Meta.archive_collection):
+                tasks = Task.get_tasks_by_robot(robot_id)
+                for task in tasks:
+                    task_status = TaskStatus.objects.get({"_id": task.task_id})
+                    tasks_progress.append(task_status.progress.actions)
+        return tasks_progress
+
+    def run(self):
+        while self.timetable_monitor.completed_tasks:
+            task = self.timetable_monitor.completed_tasks.pop(0)
+            self.task_performance_tracker.update_execution_metrics(task)
+
+            for robot_id in task.assigned_robots:
+                tasks_progress = self.get_tasks_progress(robot_id)
+                self.robot_performance_tracker.update_metrics(robot_id, tasks_progress)

--- a/mrs/robot_proxy.py
+++ b/mrs/robot_proxy.py
@@ -72,7 +72,7 @@ class RobotProxy:
     def _update_timetable(self, task, action_progress):
         if action_progress.start_time and action_progress.finish_time:
             self.logger.debug("Updating timetable")
-            action = Action.get_action(action_progress.action_id)
+            action = Action.get_action(action_progress.action.action_id)
             start_node, finish_node = action.get_node_names()
             self.timetable.update_timetable(task.task_id, start_node, finish_node,
                                             action_progress.r_start_time, action_progress.r_finish_time)
@@ -85,19 +85,24 @@ class RobotProxy:
         first_action = task.plan[0].actions[0]
         last_action = task.plan[0].actions[-1]
 
-        if action_progress.action_id == first_action.action_id and \
+        if action_progress.action.action_id == first_action.action_id and \
                 action_progress.start_time and not task.start_time:
             self.logger.debug("Task %s start time %s", task.task_id, action_progress.start_time)
             task.update_start_time(action_progress.start_time)
 
-        elif action_progress.action_id == last_action.action_id and \
+        elif action_progress.action.action_id == last_action.action_id and \
                 action_progress.finish_time and not task.finish_time:
             self.logger.debug("Task %s finish time %s", task.task_id, action_progress.finish_time)
             task.update_finish_time(action_progress.finish_time)
 
     def _update_task_progress(self, task, action_progress):
         self.logger.debug("Updating task progress of task %s", task.task_id)
-        task.update_progress(action_progress.action_id, action_progress.status)
+        kwargs = {}
+        if action_progress.start_time:
+            kwargs.update(start_time=action_progress.start_time)
+        if action_progress.finish_time:
+            kwargs.update(finish_time=action_progress.finish_time)
+        task.update_progress(action_progress.action.action_id, action_progress.status, **kwargs)
 
     def _remove_task(self, task, status):
         self.logger.critical("Deleting task %s from timetable and changing its status to %s", task.task_id, status)

--- a/mrs/timetable/timetable.py
+++ b/mrs/timetable/timetable.py
@@ -137,22 +137,22 @@ class Timetable(STNInterface):
             except DoesNotExist:
                 self.logger.warning("Task %s is not in db or its first node is not the start node", task_id)
 
-    def get_r_time(self, task_id, node_type='start', lower_bound=True):
+    def get_r_time(self, task_id, node_type, lower_bound):
         r_time = self.dispatchable_graph.get_time(task_id, node_type, lower_bound)
         return r_time
 
-    def get_start_time(self, task_id):
-        r_start_time = self.get_r_time(task_id)
+    def get_start_time(self, task_id, lower_bound=True):
+        r_start_time = self.get_r_time(task_id, 'start', lower_bound)
         start_time = self.ztp + timedelta(seconds=r_start_time)
         return start_time
 
-    def get_pickup_time(self, task_id):
-        r_pickup_time = self.get_r_time(task_id, 'pickup', False)
+    def get_pickup_time(self, task_id, lower_bound=True):
+        r_pickup_time = self.get_r_time(task_id, 'pickup', lower_bound)
         pickup_time = self.ztp + timedelta(seconds=r_pickup_time)
         return pickup_time
 
-    def get_delivery_time(self, task_id):
-        r_delivery_time = self.get_r_time(task_id, 'delivery', False)
+    def get_delivery_time(self, task_id, lower_bound=True):
+        r_delivery_time = self.get_r_time(task_id, 'delivery', lower_bound)
         delivery_time = self.ztp + timedelta(seconds=r_delivery_time)
         return delivery_time
 

--- a/mrs/timetable/timetable_monitor.py
+++ b/mrs/timetable/timetable_monitor.py
@@ -65,7 +65,7 @@ class TimetableMonitor(SimulatorInterface):
         if action_progress.start_time and action_progress.finish_time:
             timetable = self.timetable_manager.get_timetable(robot_id)
             self.logger.debug("Updating timetable of robot %s", robot_id)
-            action = Action.get_action(action_progress.action_id)
+            action = Action.get_action(action_progress.action.action_id)
             start_node, finish_node = action.get_node_names()
             timetable.update_timetable(task.task_id, start_node, finish_node,
                                        action_progress.r_start_time, action_progress.r_finish_time)
@@ -78,19 +78,24 @@ class TimetableMonitor(SimulatorInterface):
         first_action = task.plan[0].actions[0]
         last_action = task.plan[0].actions[-1]
 
-        if action_progress.action_id == first_action.action_id and\
+        if action_progress.action.action_id == first_action.action_id and\
                 action_progress.start_time and not task.start_time:
             self.logger.debug("Task %s start time %s", task.task_id, action_progress.start_time)
             task.update_start_time(action_progress.start_time)
 
-        elif action_progress.action_id == last_action.action_id and\
+        elif action_progress.action.action_id == last_action.action_id and\
                 action_progress.finish_time and not task.finish_time:
             self.logger.debug("Task %s finish time %s", task.task_id, action_progress.finish_time)
             task.update_finish_time(action_progress.finish_time)
 
     def _update_task_progress(self, task, action_progress):
         self.logger.debug("Updating task progress of task %s", task.task_id)
-        task.update_progress(action_progress.action_id, action_progress.status)
+        kwargs = {}
+        if action_progress.start_time:
+            kwargs.update(start_time=action_progress.start_time)
+        if action_progress.finish_time:
+            kwargs.update(finish_time=action_progress.finish_time)
+        task.update_progress(action_progress.action.action_id, action_progress.status, **kwargs)
 
     def _re_allocate(self, task):
         self.logger.critical("Re-allocating task %s", task.task_id)

--- a/mrs/timetable/timetable_monitor.py
+++ b/mrs/timetable/timetable_monitor.py
@@ -21,6 +21,7 @@ class TimetableMonitor(SimulatorInterface):
         self.api = kwargs.get('api')
 
         self.tasks_to_remove = list()
+        self.completed_tasks = list()
         self.logger = logging.getLogger("mrs.timetable.monitor")
 
     def task_progress_cb(self, msg):
@@ -154,4 +155,6 @@ class TimetableMonitor(SimulatorInterface):
 
         for task, status in ready_to_be_removed:
             self.tasks_to_remove.remove((task, status))
+            if status == TaskStatusConst.COMPLETED:
+                self.completed_tasks.append(task)
             self._remove_task(task, status)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 pymodm
+pymongo
 importlib_resources
 simpy
-git+https://github.com/anenriquez/fmlib.git@feature/action-manager
+git+https://github.com/anenriquez/fmlib.git@feature/action-progress-time
 git+https://github.com/anenriquez/mrta_stn.git@develop#egg=stn


### PR DESCRIPTION
- Add task and robot performance models to db.
- Add PerformanceTracker to update db performance models. 
- Use ActionProgress from fmlib (includes start_time and finish_time)
- auctioneer: Set soft constraints before creating round
- round: Add method to get_time_to_allocate 
- rond: Use datetime.now() to initialize start_time
-  tests/allocate: Show number of completed, canceled and aborted tasks 