### PR TITLE
Add time validity checks and mark tasks as delayed

### DIFF
--- a/mrs/allocation/bidding_rule.py
+++ b/mrs/allocation/bidding_rule.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from mrs.messages.bid import Bid, Metrics
 from stn.exceptions.stp import NoSTPSolution
 
@@ -28,6 +30,11 @@ class BiddingRule(object):
                           round_id,
                           Metrics(temporal_metric, risk_metric),
                           alternative_start_time=alternative_start_time)
+
+            if allocation_info.insertion_point == 1:
+                r_earliest_start_time = dispatchable_graph.get_time(task.task_id, "start")
+                earliest_start_time = self.timetable.ztp + timedelta(seconds=r_earliest_start_time)
+                bid.earliest_start_time = earliest_start_time
 
             bid.set_allocation_info(allocation_info)
             bid.set_stn(stn)

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -39,7 +39,7 @@ auctioneer:
 
 dispatcher:
   freeze_window: 0.1 # minutes
-  n_queued_tasks: 2
+  n_queued_tasks: 3
 
 bidder:
   bidding_rule: completion_time
@@ -112,8 +112,6 @@ ccu_api:
         component: 'timetable_monitor.task_progress_cb'
       - msg_type: 'RE-ALLOCATE'
         component: 'timetable_monitor.re_allocate_cb'
-      - msg_type: 'RE-ALLOCATE'
-        component: 'performance_tracker.re_allocate_cb'
       - msg_type: 'ABORT'
         component: 'timetable_monitor.abort_cb'
       - msg_type: 'RE-SCHEDULE'

--- a/mrs/db/models/task.py
+++ b/mrs/db/models/task.py
@@ -142,8 +142,14 @@ class Task(BaseTask):
         self.save()
 
     def mark_as_delayed(self):
-        self.status.delayed = True
-        self.save()
+        task_status = Task.get_task_status(self.task_id)
+        task_status.delayed = True
+        task_status.save()
+
+    def unmark_as_delayed(self):
+        task_status = Task.get_task_status(self.task_id)
+        task_status.delayed = False
+        task_status.save()
 
     def update_start_time(self, start_time):
         self.start_time = start_time
@@ -154,12 +160,14 @@ class Task(BaseTask):
         self.save()
 
     def get_timepoint_constraint(self, name):
-        return [constraint for constraint in self.constraints.timepoint_constraints
-                if constraint.name == name].pop()
+        for constraint in self.constraints.timepoint_constraints:
+            if constraint.name == name:
+                return constraint
 
     def get_inter_timepoint_constraint(self, name):
-        return [constraint for constraint in self.constraints.inter_timepoint_constraints
-                if constraint.name == name].pop()
+        for constraint in self.constraints.inter_timepoint_constraints:
+            if constraint.name == name:
+                return constraint
 
     def get_timepoint_constraints(self):
         return self.constraints.timepoint_constraints

--- a/mrs/experiments/results/generator.py
+++ b/mrs/experiments/results/generator.py
@@ -107,7 +107,7 @@ class Run(AsDictMixin):
     def get_allocated_tasks(self):
         allocated_tasks = list()
         for performance in self._run_info.tasks_performance:
-            if performance.allocation.allocated:
+            if performance.allocation and performance.allocation.allocated:
                 allocated_tasks.append(performance.task_id)
         return allocated_tasks
 
@@ -183,7 +183,9 @@ class Run(AsDictMixin):
     def get_start_finish_time(self):
         start_time = datetime.max
         finish_time = datetime.min
-        for task_status in self._run_info.tasks_status:
+        task_status = [task_status for task_status in self._run_info.tasks_status
+                       if task_status.status == TaskStatusConst.COMPLETED]
+        for task_status in task_status:
             for action_progress in task_status.progress.actions:
                 if action_progress.start_time < start_time:
                     start_time = action_progress.start_time

--- a/mrs/messages/bid.py
+++ b/mrs/messages/bid.py
@@ -61,6 +61,7 @@ class Bid(BidBase):
     def __init__(self, task_id, robot_id, round_id, metrics, **kwargs):
         self.metrics = metrics
         self._allocation_info = None
+        self.earliest_start_time = kwargs.get("earliest_start_time")
         self.alternative_start_time = kwargs.get("alternative_start_time")
         super().__init__(task_id, robot_id, round_id)
 

--- a/mrs/messages/d_graph_update.py
+++ b/mrs/messages/d_graph_update.py
@@ -20,7 +20,7 @@ class DGraphUpdate(AsDictMixin):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def update_timetable(self, timetable, replace=False):
+    def update_timetable(self, timetable, replace=True):
         stn_cls = timetable.stp_solver.get_stn()
         stn = stn_cls.from_dict(self.stn)
         dispatchable_graph = stn_cls.from_dict(self.dispatchable_graph)

--- a/mrs/messages/recover.py
+++ b/mrs/messages/recover.py
@@ -21,9 +21,8 @@ class ReAllocate(Recover):
 
 
 class Abort(Recover):
-    def __init__(self, method, task_id, status):
+    def __init__(self, method, task_id):
         super().__init__(method, task_id)
-        self.status = status
 
     @property
     def meta_model(self):

--- a/mrs/messages/task_announcement.py
+++ b/mrs/messages/task_announcement.py
@@ -6,7 +6,7 @@ from mrs.utils.as_dict import AsDictMixin
 
 
 class TaskAnnouncement(AsDictMixin):
-    def __init__(self, tasks, round_id, zero_timepoint):
+    def __init__(self, tasks, round_id, zero_timepoint, earliest_admissible_time):
         """
         Constructor for the TaskAnnouncement object
 
@@ -23,6 +23,7 @@ class TaskAnnouncement(AsDictMixin):
         else:
             self.round_id = round_id
 
+        self.earliest_admissible_time = earliest_admissible_time
         self.zero_timepoint = zero_timepoint
 
     def to_dict(self):

--- a/mrs/messages/task_progress.py
+++ b/mrs/messages/task_progress.py
@@ -3,9 +3,10 @@ from mrs.utils.as_dict import AsDictMixin
 
 
 class TaskProgress(AsDictMixin):
-    def __init__(self, task_id, status, robot_id, action_progress):
+    def __init__(self, task_id, status, robot_id, action_progress, delayed=False):
         self.task_id = task_id
         self.status = status
+        self.delayed = delayed
         self.robot_id = robot_id
         self.action_progress = action_progress
 

--- a/mrs/performance/tracker.py
+++ b/mrs/performance/tracker.py
@@ -2,10 +2,10 @@ import logging
 
 from fmlib.models.tasks import TaskStatus
 from mrs.db.models.task import Task
-from mrs.messages.recover import ReAllocate
 from mrs.performance.robot import RobotPerformanceTracker
 from mrs.performance.task import TaskPerformanceTracker
 from pymodm.context_managers import switch_collection
+from ropod.structs.status import TaskStatus as TaskStatusConst
 
 
 class PerformanceTracker:
@@ -19,11 +19,6 @@ class PerformanceTracker:
 
         self.logger = logging.getLogger("mrs.performance.tracker")
 
-    def re_allocate_cb(self, msg):
-        payload = msg['payload']
-        recover = ReAllocate.from_payload(payload)
-        self.task_performance_tracker.update_re_allocations(recover.task_id)
-
     def update_task_allocation_metrics(self, allocated_task_id, robot_ids, tasks_to_update):
         for robot_id in robot_ids:
             timetable = self.timetable_manager.get_timetable(robot_id)
@@ -33,10 +28,11 @@ class PerformanceTracker:
     def get_tasks_progress(robot_id):
         tasks_progress = list()
         with switch_collection(Task, Task.Meta.archive_collection):
-            with switch_collection(TaskStatus, TaskStatus.Meta.archive_collection):
-                tasks = Task.get_tasks_by_robot(robot_id)
-                for task in tasks:
-                    task_status = TaskStatus.objects.get({"_id": task.task_id})
+            tasks = Task.get_tasks_by_robot(robot_id)
+        with switch_collection(TaskStatus, TaskStatus.Meta.archive_collection):
+            for task in tasks:
+                task_status = TaskStatus.objects.get({"_id": task.task_id})
+                if task_status.status == TaskStatusConst.COMPLETED:
                     tasks_progress.append(task_status.progress.actions)
         return tasks_progress
 
@@ -48,3 +44,7 @@ class PerformanceTracker:
             for robot_id in task.assigned_robots:
                 tasks_progress = self.get_tasks_progress(robot_id)
                 self.robot_performance_tracker.update_metrics(robot_id, tasks_progress)
+
+        while self.timetable_monitor.tasks_to_reallocate:
+            task_id = self.timetable_monitor.tasks_to_reallocate.pop(0)
+            self.task_performance_tracker.update_re_allocations(task_id)

--- a/mrs/robot_proxy.py
+++ b/mrs/robot_proxy.py
@@ -105,6 +105,9 @@ class RobotProxy:
 
     def _remove_task(self, task, status):
         self.logger.critical("Deleting task %s from timetable and changing its status to %s", task.task_id, status)
+        if status == TaskStatusConst.COMPLETED:
+            x, y, theta = self.bidder.planner.get_pose(task.request.delivery_location)
+            self.robot_model.update_position(x=x, y=y, theta=theta)
         self.timetable.remove_task(task.task_id)
         self.bidder.changed_timetable = True
         task.unfreeze()

--- a/mrs/utils/as_dict.py
+++ b/mrs/utils/as_dict.py
@@ -50,14 +50,15 @@ class AsDictMixin:
     def to_attrs(cls, dict_repr):
         attrs = dict()
         for key, value in dict_repr.items():
-            attrs[key] = cls._get_value(key, value)
+            if value is not None:
+                attrs[key] = cls._get_value(key, value)
         return attrs
 
     @classmethod
     def _get_value(cls, key, value):
-        if key == 'task_id' or key == 'round_id' or key == 'action_id':
+        if key in ['task_id', 'round_id', 'action_id']:
             return from_str(value)
-        elif key == 'zero_timepoint':
+        elif key in ['zero_timepoint', 'earliest_admissible_time', 'earliest_start_time']:
             return TimeStamp.from_str(value)
         else:
             return value


### PR DESCRIPTION
Auctioneer:
- Check the validity of the earliest start time for bids where the task is inserted in the first position of the STN. A valid earliest start time is later than the current time. 
- Add `undo_allocation` method. 
- If a task is invalid and the option `alternative_timeslots` is deactivated, change task status to ABORTED instead of only removing it.
- Add earliest admissible time to TaskAnnouncement. This is the earliest time at which the first task in the schedule is allowed to begin. Used to avoid bids where tasks start in the past. (Bidders are oblivious of the current time)

Bidder:
- Send no-bids before sending bids. The auctioneer closes the round once all robots placed a bid or at the closure time (whatever happens first). Send no-bids first to allow the auctioneer to process them, before closing the round. 

Bidding rule:
Add `earliest_start_time` to bids for tasks that are inserted in the first position of the STN. 

Round: 
- If a task only received soft-bids and the `alternative_timeslots` option is deactivated, change task status to ABORTED instead of removing it.

config:
- Change n_queued_tasks to three. 

Tasks:
- Fix `get_constraint` methods. If the constraint did not exist the method popped from an empty list, causing an error. 
- Fix method `mark_as_delayed`. Get the `task_status` and save it. 
- Add method `unmark_as_delayed`

DelayRecovery:
- Move `is_next_task_late` to the Timetable class.

Executor:
- Refactor `update_action_progress` into a method
- Mark task as delayed if the assigned time violates the pickup constraint

Experiment:
- Do not switch connection before gathering results. The current connection is the ccu_store db. 

Generator: 
- Get the start and finish times base on COMPLETED tasks.

Bid
- Add optional attr `earliest_start_time`

D_Graph_Update:
- Make `update_timetable` replace option default

Robot:
Replace timetable based on `d_graph_update`
Apply recovery method before updating the action progress

TaskAnnouncement
- Add attr `earliest_admissible_time`

TaskProgress
- Add `delayed` attr.

PerformanceTracker:
- Update re-allocations based on the list of tasks_to_reallocate from the TimetableMonitor.

TimetableMonitor
- Add recovery-method.
- Add tasks_to_reallocate.
- Mark task a delayed based on the TaskProgress msg.
- Empty `assigned_robots` and `plan` before re-allocating a task.
- Add method to abort task.
- Check the validity of the following tasks before deleting a COMPLETED task. Apply recovery method if necessary.

STN_interface:
- The `earliest_start_time` of the task in the first insertion point cannot be earlier than the `earliest_admissible_time`
- The earliest pickup time of a task with soft constraints is the earliest delivery time of the previous task plus the mean travel time

Timetable:
- Add methods `is_next_task_late`, `is_next_task_invalid`