### PR TITLE
Add msgs: task-contract-cancellaction  and round-finished

### DIFF
--- a/experiments/run.py
+++ b/experiments/run.py
@@ -43,7 +43,17 @@ class RunExperiment:
                 allocate.check_termination_test()
                 time.sleep(0.5)
 
-            Experiment.create_new(self.experiment_name, self.approach, dataset, self.new_run)
+            bidding_rule = self.config_params.get("bidder").get("bidding_rule")
+
+            self.logger.info("Creating experiment model for db")
+            experiment = Experiment.create_new(self.experiment_name, self.approach, bidding_rule, dataset, self.new_run)
+            self.logger.info("Experiment: %s \n id: %s \n Approach: %s \n Bidding rule %s \n "
+                             "Dataset: %s",
+                             experiment.name,
+                             experiment.run_id,
+                             experiment.approach,
+                             experiment.bidding_rule,
+                             experiment.dataset)
             allocate.terminate()
 
         except (KeyboardInterrupt, SystemExit):

--- a/mrs/allocate.py
+++ b/mrs/allocate.py
@@ -105,21 +105,23 @@ class Allocate(RopodPyre):
             self.logger.debug("Task progress received: %s", progress)
 
     def check_termination_test(self):
+        planned_tasks = Task.get_tasks_by_status(TaskStatusConst.PLANNED)
         with switch_collection(TaskStatus, TaskStatus.Meta.archive_collection):
             completed_tasks = Task.get_tasks_by_status(TaskStatusConst.COMPLETED)
             canceled_tasks = Task.get_tasks_by_status(TaskStatusConst.CANCELED)
             aborted_tasks = Task.get_tasks_by_status(TaskStatusConst.ABORTED)
 
-            self.logger.info("Number of completed tasks: %s ", len(completed_tasks))
-            self.logger.info("Number of canceled tasks: %s", len(canceled_tasks))
-            self.logger.info("Number of aborted tasks: %s", len(aborted_tasks))
+        self.logger.info("Number of planned tasks: %s ", len(planned_tasks))
+        self.logger.info("Number of completed tasks: %s ", len(completed_tasks))
+        self.logger.info("Number of canceled tasks: %s", len(canceled_tasks))
+        self.logger.info("Number of aborted tasks: %s", len(aborted_tasks))
 
-            tasks = completed_tasks + canceled_tasks + aborted_tasks
+        tasks = completed_tasks + canceled_tasks + aborted_tasks
 
-            if len(tasks) == len(self.tasks):
-                self.logger.info("Terminating test")
-                self.logger.info("Allocations: %s", self.allocations)
-                self.terminated = True
+        if len(tasks) == len(self.tasks):
+            self.logger.info("Terminating test")
+            self.logger.info("Allocations: %s", self.allocations)
+            self.terminated = True
 
     def terminate(self):
         print("Exiting test...")

--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -252,7 +252,7 @@ class Auctioneer(SimulatorInterface):
         if robot_id not in self.changed_timetable:
             task_contract = TaskContract(task_id, robot_id)
             msg = self.api.create_message(task_contract)
-            self.api.publish(msg, peer=robot_id + "_proxy")
+            self.api.publish(msg, groups=['TASK-ALLOCATION'])
         else:
             self.logger.warning("Round %s has to be repeated", self.round.id)
             self.finish_round()

--- a/mrs/allocation/bidder.py
+++ b/mrs/allocation/bidder.py
@@ -75,16 +75,17 @@ class Bidder:
     def task_contract_cb(self, msg):
         payload = msg['payload']
         task_contract = TaskContract.from_payload(payload)
-        self.logger.debug("Robot %s received TASK-CONTRACT", self.robot_id)
+        if task_contract.robot_id == self.robot_id:
+            self.logger.debug("Robot %s received TASK-CONTRACT", self.robot_id)
 
-        if not self.changed_timetable:
-            self.allocate_to_robot(task_contract.task_id)
-            self.send_contract_acknowledgement(task_contract, accept=True)
-        else:
-            self.logger.warning("The timetable changed before the round was completed, "
-                                "as a result, the bid placed %s is no longer valid ",
-                                self.bid_placed)
-            self.send_contract_acknowledgement(task_contract, accept=False)
+            if not self.changed_timetable:
+                self.allocate_to_robot(task_contract.task_id)
+                self.send_contract_acknowledgement(task_contract, accept=True)
+            else:
+                self.logger.warning("The timetable changed before the round was completed, "
+                                    "as a result, the bid placed %s is no longer valid ",
+                                    self.bid_placed)
+                self.send_contract_acknowledgement(task_contract, accept=False)
 
     def round_finished_cb(self, msg):
         payload = msg['payload']

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -45,12 +45,12 @@ class Round(SimulatorInterface):
 
         After the round closes, the election process takes place
 
-        finished: The election process is over, i.e., an mrs has been made
+        finished: The election process is over, i.e., an allocation has been made
                     (or an exception has been raised)
 
         """
         open_time = self.get_current_time()
-        self.logger.debug("Round  %s opened at %s and will close at %s",
+        self.logger.debug("Round %s opened at %s and will close at %s",
                           self.id, open_time, self.closure_time)
 
         self.finished = False

--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -1,8 +1,11 @@
 import argparse
 import logging.config
-import time
 
 from fmlib.models.tasks import TaskPlan
+from planner.planner import Planner
+from ropod.structs.status import TaskStatus as TaskStatusConst
+from ropod.utils.uuid import generate_uuid
+
 from mrs.allocation.auctioneer import Auctioneer
 from mrs.config.configurator import Configurator
 from mrs.config.params import get_config_params
@@ -17,9 +20,6 @@ from mrs.performance.tracker import PerformanceTracker
 from mrs.simulation.simulator import Simulator, SimulatorInterface
 from mrs.timetable.manager import TimetableManager
 from mrs.timetable.monitor import TimetableMonitor
-from planner.planner import Planner
-from ropod.structs.status import TaskStatus as TaskStatusConst
-from ropod.utils.uuid import generate_uuid
 
 _component_modules = {'simulator': Simulator,
                       'timetable_manager': TimetableManager,
@@ -54,8 +54,9 @@ class CCU:
         self.task_plans = dict()
 
     def start_test_cb(self, msg):
-        self.logger.debug("Start test msg received")
+        self.simulator_interface.stop()
         initial_time = msg["payload"]["initial_time"]
+        self.logger.info("Start test at %s", initial_time)
 
         tasks = Task.get_tasks_by_status(TaskStatusConst.UNALLOCATED)
         for robot_id in self.auctioneer.robot_ids:
@@ -128,7 +129,6 @@ class CCU:
                 self.process_allocation()
                 self.performance_tracker.run()
                 self.api.run()
-                time.sleep(0.1)
         except (KeyboardInterrupt, SystemExit):
             self.api.shutdown()
             self.simulator_interface.stop()

--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -1,5 +1,6 @@
 import argparse
 import logging.config
+import time
 
 from fmlib.models.tasks import TaskPlan
 from mrs.allocation.auctioneer import Auctioneer
@@ -98,7 +99,7 @@ class CCU:
             for robot_id in robot_ids:
                 self.dispatcher.send_d_graph_update(robot_id)
 
-            self.auctioneer.round.finish()
+            self.auctioneer.finish_round()
 
     def update_task_allocation_metrics(self, task_id, robot_ids):
         tasks_to_update = [pre_task_action.task_id for pre_task_action in self.auctioneer.pre_task_actions]
@@ -127,6 +128,7 @@ class CCU:
                 self.process_allocation()
                 self.performance_tracker.run()
                 self.api.run()
+                time.sleep(0.1)
         except (KeyboardInterrupt, SystemExit):
             self.api.shutdown()
             self.simulator_interface.stop()

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -82,10 +82,10 @@ ccu_api:
       task-contract:
         msg_type: 'TASK-CONTRACT'
         groups: ['TASK-ALLOCATION']
-        method: shout
-      task-contract-acknowledgement:
+        method: whisper
+      task-contract-cancellation:
         groups: ['TASK-ALLOCATION']
-        msg_type: 'TASK-CONTRACT-ACKNOWLEDGEMENT'
+        msg_type: 'TASK-CONTRACT-CANCELLATION'
         method: whisper
       task:
         msg_type: 'TASK'
@@ -131,7 +131,7 @@ robot_proxy_api:
         - TASK
         - TASK-ANNOUNCEMENT
         - TASK-CONTRACT
-        - TASK-CONTRACT-ACKNOWLEDGEMENT
+        - TASK-CONTRACT-CANCELLATION
         - ROBOT-POSE
         - TASK-PROGRESS
         - REMOVE-TASK
@@ -149,14 +149,14 @@ robot_proxy_api:
       task-contract-acknowledgement:
         groups: ['TASK-ALLOCATION']
         msg_type: 'TASK-CONTRACT-ACKNOWLEDGEMENT'
-        method: shout
+        method: whisper
     callbacks:
       - msg_type: 'TASK-ANNOUNCEMENT'
         component: 'bidder.task_announcement_cb'
       - msg_type: 'TASK-CONTRACT'
         component: 'bidder.task_contract_cb'
-      - msg_type: 'TASK-CONTRACT-ACKNOWLEDGEMENT'
-        component: 'bidder.task_contract_acknowledgement_cb'
+      - msg_type: 'TASK-CONTRACT-CANCELLATION'
+        component: 'bidder.task_contract_cancellation_cb'
       - msg_type: 'ROBOT-POSE'
         component: '.robot_pose_cb'
       - msg_type: 'REMOVE-TASK'

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -87,6 +87,10 @@ ccu_api:
         groups: ['TASK-ALLOCATION']
         msg_type: 'TASK-CONTRACT-CANCELLATION'
         method: whisper
+      round-finished:
+        groups: ['TASK-ALLOCATION']
+        msg_type: 'ROUND-FINISHED'
+        method: shout
       task:
         msg_type: 'TASK'
         groups: ['TASK-ALLOCATION']
@@ -132,6 +136,7 @@ robot_proxy_api:
         - TASK-ANNOUNCEMENT
         - TASK-CONTRACT
         - TASK-CONTRACT-CANCELLATION
+        - ROUND-FINISHED
         - ROBOT-POSE
         - TASK-PROGRESS
         - REMOVE-TASK
@@ -157,6 +162,8 @@ robot_proxy_api:
         component: 'bidder.task_contract_cb'
       - msg_type: 'TASK-CONTRACT-CANCELLATION'
         component: 'bidder.task_contract_cancellation_cb'
+      - msg_type: 'ROUND-FINISHED'
+        component: 'bidder.round_finished_cb'
       - msg_type: 'ROBOT-POSE'
         component: '.robot_pose_cb'
       - msg_type: 'REMOVE-TASK'

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -82,7 +82,7 @@ ccu_api:
       task-contract:
         msg_type: 'TASK-CONTRACT'
         groups: ['TASK-ALLOCATION']
-        method: whisper
+        method: shout
       task-contract-cancellation:
         groups: ['TASK-ALLOCATION']
         msg_type: 'TASK-CONTRACT-CANCELLATION'

--- a/mrs/db/models/performance/robot.py
+++ b/mrs/db/models/performance/robot.py
@@ -44,6 +44,10 @@ class RobotPerformance(MongoModel):
         self.allocated_tasks.append(task_id)
         self.save()
 
+    def unallocated(self, task_id):
+        self.allocated_tasks.pop(task_id)
+        self.save()
+
     def update_travel_time(self, travel_time):
         self.travel_time += travel_time
         self.save()

--- a/mrs/messages/bid.py
+++ b/mrs/messages/bid.py
@@ -1,4 +1,6 @@
+from mrs.db.models.actions import GoTo
 from mrs.utils.as_dict import AsDictMixin
+from stn.task import Task as STNTask
 
 
 class Metrics(AsDictMixin):
@@ -104,6 +106,64 @@ class Bid(BidBase):
     def to_attrs(cls, dict_repr):
         attrs = super().to_attrs(dict_repr)
         attrs.update(metrics=Metrics.from_dict(dict_repr.get("metrics")))
+        return attrs
+
+
+class AllocationInfo(AsDictMixin):
+    def __init__(self, insertion_point, pre_task_actions, new_task, next_task=None, prev_version_next_task=None):
+        self.insertion_point = insertion_point
+        self.pre_task_actions = pre_task_actions
+        self.new_task = new_task
+        self.next_task = next_task
+        self.prev_version_next_task = prev_version_next_task
+        self._stn = None
+        self._dispatchable_graph = None
+
+    def update_next_task(self, next_task, prev_version_next_task):
+        self.next_task = next_task
+        self.prev_version_next_task = prev_version_next_task
+
+    @property
+    def stn(self):
+        return self._stn
+
+    @stn.setter
+    def stn(self, stn):
+        self._stn = stn
+
+    @property
+    def dispatchable_graph(self):
+        return self._dispatchable_graph
+
+    @dispatchable_graph.setter
+    def dispatchable_graph(self, dispatchable_graph):
+        self._dispatchable_graph = dispatchable_graph
+
+    def to_dict(self):
+        dict_repr = super().to_dict()
+        pre_task_actions = list()
+        for action in self.pre_task_actions:
+            pre_task_actions.append(action.to_dict())
+        dict_repr.update(pre_task_actions=pre_task_actions)
+        return dict_repr
+
+    @classmethod
+    def to_attrs(cls, dict_repr):
+        attrs = super().to_attrs(dict_repr)
+        new_task = attrs.get("new_task")
+        next_task = attrs.get("next_task")
+        prev_version_next_task = attrs.get("prev_version_next_task")
+
+        pre_task_actions = list()
+        for action in attrs.get("pre_task_actions"):
+            pre_task_actions.append(GoTo.from_payload(action))
+        attrs.update(pre_task_actions=pre_task_actions)
+
+        attrs.update(new_task=STNTask.from_dict(new_task))
+        if next_task and prev_version_next_task:
+            attrs.update(next_task=STNTask.from_dict(next_task))
+            attrs.update(prev_version_next_task=STNTask.from_dict(prev_version_next_task))
+
         return attrs
 
 

--- a/mrs/messages/round_finished.py
+++ b/mrs/messages/round_finished.py
@@ -1,0 +1,10 @@
+from mrs.utils.as_dict import AsDictMixin
+
+
+class RoundFinished(AsDictMixin):
+    def __init__(self, round_id):
+        self.round_id = round_id
+
+    @property
+    def meta_model(self):
+        return "round-finished"

--- a/mrs/messages/task_contract.py
+++ b/mrs/messages/task_contract.py
@@ -1,7 +1,6 @@
-from stn.task import Task as STNTask
-
-from mrs.db.models.actions import GoTo
+from mrs.messages.bid import AllocationInfo
 from mrs.utils.as_dict import AsDictMixin
+from stn.task import Task as STNTask
 
 
 class TaskContract(AsDictMixin):
@@ -14,70 +13,10 @@ class TaskContract(AsDictMixin):
         return "task-contract"
 
 
-class AllocationInfo(AsDictMixin):
-    def __init__(self, insertion_point, stn_tasks, pre_task_actions):
-        self.insertion_point = insertion_point
-        self.stn_tasks = stn_tasks
-        self.pre_task_actions = pre_task_actions
-        self._stn = None
-        self._dispatchable_graph = None
-
-    @property
-    def stn(self):
-        return self._stn
-
-    @stn.setter
-    def stn(self, stn):
-        self._stn = stn
-
-    @property
-    def dispatchable_graph(self):
-        return self._dispatchable_graph
-
-    @dispatchable_graph.setter
-    def dispatchable_graph(self, dispatchable_graph):
-        self._dispatchable_graph = dispatchable_graph
-
-    def get_stn_tasks(self, task_id):
-        new_stn_task = None
-        next_stn_task = None
-        for stn_task in self.stn_tasks:
-            if stn_task.task_id == task_id:
-                new_stn_task = stn_task
-            else:
-                next_stn_task = stn_task
-        return new_stn_task, next_stn_task
-
-    def to_dict(self):
-        dict_repr = super().to_dict()
-        stn_tasks = list()
-        pre_task_actions = list()
-        for task in self.stn_tasks:
-            stn_tasks.append(task.to_dict())
-        for action in self.pre_task_actions:
-            pre_task_actions.append(action.to_dict())
-        dict_repr.update(pre_task_actions=pre_task_actions)
-        dict_repr.update(stn_tasks=stn_tasks)
-        return dict_repr
-
-    @classmethod
-    def to_attrs(cls, dict_repr):
-        attrs = super().to_attrs(dict_repr)
-        stn_tasks = list()
-        pre_task_actions = list()
-        for task in attrs.get("stn_tasks"):
-            stn_tasks.append(STNTask.from_dict(task))
-        for action in attrs.get("pre_task_actions"):
-            pre_task_actions.append(GoTo.from_payload(action))
-        attrs.update(stn_tasks=stn_tasks)
-        attrs.update(pre_task_actions=pre_task_actions)
-        return attrs
-
-
 class TaskContractAcknowledgment(TaskContract):
     def __init__(self, task_id, robot_id, allocation_info, accept=True):
-        self.allocation_info = allocation_info
         super().__init__(task_id, robot_id)
+        self.allocation_info = allocation_info
         self.accept = accept
 
     @classmethod
@@ -89,3 +28,21 @@ class TaskContractAcknowledgment(TaskContract):
     @property
     def meta_model(self):
         return "task-contract-acknowledgement"
+
+
+class TaskContractCancellation(TaskContract):
+    def __init__(self, task_id, robot_id, prev_version_next_task=None):
+        super().__init__(task_id, robot_id)
+        self.prev_version_next_task = prev_version_next_task
+
+    @classmethod
+    def to_attrs(cls, dict_repr):
+        attrs = super().to_attrs(dict_repr)
+        prev_version_next_task = attrs.get("prev_version_next_task")
+        if prev_version_next_task:
+            attrs.update(prev_version_next_task=STNTask.from_dict(prev_version_next_task))
+        return attrs
+
+    @property
+    def meta_model(self):
+        return "task-contract-cancellation"

--- a/mrs/performance/robot.py
+++ b/mrs/performance/robot.py
@@ -43,3 +43,8 @@ class RobotPerformanceTracker:
         start_fist_task = tasks_progress[0][0].start_time
         return start_fist_task, finish_last_task
 
+    @staticmethod
+    def update_re_allocations(task):
+        for robot_id in task.assigned_robots:
+            robot_performance = RobotPerformance.get_robot_performance(robot_id)
+            robot_performance.unallocated(task.task_id)

--- a/mrs/performance/task.py
+++ b/mrs/performance/task.py
@@ -54,7 +54,7 @@ class TaskPerformanceTracker:
             task_performance.update_execution(travel_time, work_time)
 
     @staticmethod
-    def update_re_allocations(task_id):
-        task_performance = TaskPerformance.get_task_performance(task_id)
+    def update_re_allocations(task):
+        task_performance = TaskPerformance.get_task_performance(task.task_id)
         task_performance.increase_n_re_allocation_attempts()
         task_performance.unallocated()

--- a/mrs/performance/tracker.py
+++ b/mrs/performance/tracker.py
@@ -38,13 +38,16 @@ class PerformanceTracker:
 
     def run(self):
         while self.timetable_monitor.completed_tasks:
-            task = self.timetable_monitor.completed_tasks.pop(0)
+            task = self.timetable_monitor.completed_tasks[0]
             self.task_performance_tracker.update_execution_metrics(task)
 
             for robot_id in task.assigned_robots:
                 tasks_progress = self.get_tasks_progress(robot_id)
                 self.robot_performance_tracker.update_metrics(robot_id, tasks_progress)
 
+            self.timetable_monitor.completed_tasks.pop(0)
+
         while self.timetable_monitor.tasks_to_reallocate:
-            task_id = self.timetable_monitor.tasks_to_reallocate.pop(0)
-            self.task_performance_tracker.update_re_allocations(task_id)
+            task = self.timetable_monitor.tasks_to_reallocate.pop(0)
+            self.task_performance_tracker.update_re_allocations(task)
+            self.robot_performance_tracker.update_re_allocations(task)

--- a/mrs/timetable/manager.py
+++ b/mrs/timetable/manager.py
@@ -48,11 +48,9 @@ class TimetableManager(object):
     def update_timetable(self, robot_id, allocation_info, task):
         timetable = self.timetables.get(robot_id)
         try:
-            for stn_task in allocation_info.stn_tasks:
-                if stn_task.task_id == task.task_id:
-                    timetable.insert_task(stn_task, allocation_info.insertion_point)
-                else:
-                    timetable.stn.update_task(stn_task)
+            timetable.insert_task(allocation_info.new_task, allocation_info.insertion_point)
+            if allocation_info.next_task:
+                timetable.update_task(allocation_info.next_task)
 
             dispatchable_graph = timetable.compute_dispatchable_graph(timetable.stn)
             timetable.dispatchable_graph = dispatchable_graph

--- a/mrs/timetable/monitor.py
+++ b/mrs/timetable/monitor.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from fmlib.models.actions import Action
 from mrs.db.models.task import Task
@@ -33,9 +32,6 @@ class TimetableMonitor(SimulatorInterface):
         progress = TaskProgress.from_payload(payload)
         self.logger.debug("Task progress received: %s", progress)
 
-        # Sometimes a DoesNotExist error is thrown, even though the task is in the db
-        # Sleep a bit before reading from the db
-        time.sleep(0.1)
         task = Task.get_task(progress.task_id)
 
         robot_id = progress.robot_id

--- a/mrs/timetable/stn_interface.py
+++ b/mrs/timetable/stn_interface.py
@@ -21,6 +21,9 @@ class STNInterface:
     def insert_task(self, stn_task, insertion_point):
         self.stn.add_task(stn_task, insertion_point)
 
+    def update_task(self, stn_task):
+        self.stn.update_task(stn_task)
+
     def to_stn_task(self, task, insertion_point, earliest_admissible_time):
         self.update_pickup_constraint(task, insertion_point)
         self.update_start_constraint(task, insertion_point, earliest_admissible_time)

--- a/mrs/utils/as_dict.py
+++ b/mrs/utils/as_dict.py
@@ -6,6 +6,7 @@ import uuid
 from fmlib.utils.messages import Document
 from ropod.utils.timestamp import TimeStamp
 from ropod.utils.uuid import from_str
+from datetime import datetime
 
 
 class AsDictMixin:
@@ -26,6 +27,8 @@ class AsDictMixin:
                 return value.to_str()
             elif isinstance(value, uuid.UUID):
                 return str(value)
+            elif isinstance(value, datetime):
+                return value.isoformat()
             else:
                 return value
         else:


### PR DESCRIPTION
- `task-contract-cancellation` msg undoes the last allocation. Sent by the auctioneer when the winner's timetable changed before the task-contract-acknowledgement was received
Before, the `task-contract-acknowledgment` msg with `accept=False` was used. The `task-contract-cancellation` includes the previous version of the next task.

- Refactor AllocationInfo:
   Move it to messages/bid.
   Replace the stn_tasks dict with STNTask objects: new_task, next_task and prev_version_next_task.

- `round-finished` msg. Sent by the auctioneer to stop robots from computing bids for a round that already closed.

- Add bidding rule to experiment. Get experiment based on dataset and bidding rule.
- results/generator: Refactor PerformanceMetrics into Fleet, Robot and TaskPerformance Metrics.

- ccu: Stop current simulation before starting a new one.

- Pass in task instead of taks_id to update_re_allocations.

- performance/robot: Add method to update allocated tasks.

- as_dict: Add check to convert datetime to isoformat.

- performance/tracker: Update robot allocated tasks after triggering re-allocation. Pop a task from the completed task once the performance metrics are updated.

- Add flags to prevent deleting a task while updating another and viceversa. Whithout this check, a DoesNotExist error is thrown when one method starts while the other method is already running. For instance, if a task is deleted while the task_progress_cb method is executing.