### PR TITLE
Fix docker implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN git clone https://github.com/anenriquez/mrta_datasets.git /opt/mrs/datasets
 WORKDIR /opt/mrs/datasets
 RUN pip3 install -r requirements.txt && pip3 install -e .
 
+ENV TZ=CET
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
 ENTRYPOINT ["/ros_entrypoint.sh"]
 
 

--- a/experiments/docker_files/exp-1-approach-10.yaml
+++ b/experiments/docker_files/exp-1-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - non_intentional_delays
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-1-approach-14.yaml
+++ b/experiments/docker_files/exp-1-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - non_intentional_delays
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-1-approach-4.yaml
+++ b/experiments/docker_files/exp-1-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - non_intentional_delays
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-1-approach-8.yaml
+++ b/experiments/docker_files/exp-1-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - non_intentional_delays
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - non_intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-2-approach-10.yaml
+++ b/experiments/docker_files/exp-2-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - intentional_delays
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-2-approach-14.yaml
+++ b/experiments/docker_files/exp-2-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - intentional_delays
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-2-approach-4.yaml
+++ b/experiments/docker_files/exp-2-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - intentional_delays
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-2-approach-8.yaml
+++ b/experiments/docker_files/exp-2-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - intentional_delays
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - intentional_delays
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-3-approach-10.yaml
+++ b/experiments/docker_files/exp-3-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - task_scalability
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-3-approach-14.yaml
+++ b/experiments/docker_files/exp-3-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - task_scalability
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-3-approach-4.yaml
+++ b/experiments/docker_files/exp-3-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - task_scalability
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-3-approach-8.yaml
+++ b/experiments/docker_files/exp-3-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - task_scalability
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - task_scalability
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-1-approach-10.yaml
+++ b/experiments/docker_files/exp-4-1-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,21 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_1
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -48,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -65,10 +60,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-1-approach-14.yaml
+++ b/experiments/docker_files/exp-4-1-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,21 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_1
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -48,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -65,10 +60,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-1-approach-4.yaml
+++ b/experiments/docker_files/exp-4-1-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,21 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_1
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -48,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -65,10 +60,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-1-approach-8.yaml
+++ b/experiments/docker_files/exp-4-1-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,21 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_1
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -48,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -65,10 +60,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_1
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-2-approach-10.yaml
+++ b/experiments/docker_files/exp-4-2-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,23 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_2
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -50,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -67,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -84,10 +77,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -101,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-2-approach-14.yaml
+++ b/experiments/docker_files/exp-4-2-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,23 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_2
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -50,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -67,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -84,10 +77,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -101,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-2-approach-4.yaml
+++ b/experiments/docker_files/exp-4-2-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,23 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_2
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -50,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -67,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -84,10 +77,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -101,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-2-approach-8.yaml
+++ b/experiments/docker_files/exp-4-2-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,23 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_2
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -50,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -67,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -84,10 +77,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -101,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_2
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-3-approach-10.yaml
+++ b/experiments/docker_files/exp-4-3-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,25 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_3
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -52,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -69,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -86,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -103,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -120,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -137,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-3-approach-14.yaml
+++ b/experiments/docker_files/exp-4-3-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,25 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_3
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -52,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -69,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -86,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -103,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -120,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -137,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-3-approach-4.yaml
+++ b/experiments/docker_files/exp-4-3-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,25 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_3
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -52,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -69,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -86,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -103,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -120,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -137,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-3-approach-8.yaml
+++ b/experiments/docker_files/exp-4-3-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,25 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_3
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -52,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -69,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -86,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -103,10 +94,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -120,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -137,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_3
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-4-approach-10.yaml
+++ b/experiments/docker_files/exp-4-4-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,27 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_4
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -54,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -71,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -88,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -105,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -122,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -139,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -156,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -173,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-4-approach-14.yaml
+++ b/experiments/docker_files/exp-4-4-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,27 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_4
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -54,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -71,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -88,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -105,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -122,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -139,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -156,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -173,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-4-approach-4.yaml
+++ b/experiments/docker_files/exp-4-4-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,27 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_4
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -54,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -71,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -88,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -105,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -122,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -139,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -156,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -173,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-4-approach-8.yaml
+++ b/experiments/docker_files/exp-4-4-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,27 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_4
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -54,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -71,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -88,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -105,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -122,10 +111,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -139,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -156,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -173,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_4
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-5-approach-10.yaml
+++ b/experiments/docker_files/exp-4-5-approach-10.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_5
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-5-approach-14.yaml
+++ b/experiments/docker_files/exp-4-5-approach-14.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_5
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-dsc-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-dsc-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-5-approach-4.yaml
+++ b/experiments/docker_files/exp-4-5-approach-4.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_5
     - tessi-corrective-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-corrective-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-corrective-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/docker_files/exp-4-5-approach-8.yaml
+++ b/experiments/docker_files/exp-4-5-approach-8.yaml
@@ -3,10 +3,10 @@ services:
     command:
     - python3
     - ccu.py
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: ccu
     depends_on:
     - mongo
@@ -23,29 +23,16 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_experiment:
+  mrta:
     build:
       context: ../../
       dockerfile: Dockerfile
     command:
     - python3
-    - run.py
+    - experiment.py
     - robot_scalability_5
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-experiment
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'
@@ -56,10 +43,10 @@ services:
     - python3
     - robot.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_001
     depends_on:
     - mongo
@@ -73,10 +60,10 @@ services:
     - python3
     - robot.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_002
     depends_on:
     - mongo
@@ -90,10 +77,10 @@ services:
     - python3
     - robot.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_003
     depends_on:
     - mongo
@@ -107,10 +94,10 @@ services:
     - python3
     - robot.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_004
     depends_on:
     - mongo
@@ -124,10 +111,10 @@ services:
     - python3
     - robot.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_005
     depends_on:
     - mongo
@@ -141,10 +128,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_001
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_001
     depends_on:
     - mongo
@@ -158,10 +145,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_002
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_002
     depends_on:
     - mongo
@@ -175,10 +162,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_003
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_003
     depends_on:
     - mongo
@@ -192,10 +179,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_004
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_004
     depends_on:
     - mongo
@@ -209,10 +196,10 @@ services:
     - python3
     - robot_proxy.py
     - robot_005
-    - --approach
-    - tessi-srea-preventive-re-schedule-re-allocate
     - --experiment
     - robot_scalability_5
+    - --approach
+    - tessi-srea-preventive-re-schedule-re-allocate
     container_name: robot_proxy_005
     depends_on:
     - mongo

--- a/experiments/experiment.py
+++ b/experiments/experiment.py
@@ -1,0 +1,80 @@
+import argparse
+import logging.config
+import time
+
+from mrs.allocate import Allocate
+from mrs.config.params import get_config_params
+from experiments.db.models.experiment import Experiment as ExperimentModel
+from mrs.utils.utils import load_yaml_file_from_module
+
+
+class Experiment:
+    def __init__(self, config_params, robot_poses, new_run=True):
+        self.config_params = config_params
+        self.experiment_name = config_params.get("experiment")
+        self.approach = config_params.get("approach")
+        self.robot_poses = robot_poses
+        self.new_run = new_run
+
+        self.dataset_module = config_params.get("dataset_module")
+        self.datasets = config_params.get("datasets")
+
+        self.logger = logging.getLogger('mrs.allocate')
+        logger_config = self.config_params.get('logger')
+        logging.config.dictConfig(logger_config)
+
+        self.logger.info("Experiment: %s \n Approach: %s \n Dataset Module: %s\n Datasets: %s",
+                         self.experiment_name,
+                         self.approach,
+                         self.dataset_module,
+                         self.datasets)
+
+    def start(self):
+        for dataset in self.datasets:
+            self.logger.info("Running experiment with dataset %s", dataset)
+            self.run(dataset)
+
+    def run(self, dataset):
+        allocate = Allocate(self.config_params, self.robot_poses, self.dataset_module, dataset)
+        try:
+            allocate.start_allocation()
+            while not allocate.terminated:
+                print("Approx current time: ", allocate.simulator_interface.get_current_time())
+                allocate.check_termination_test()
+                time.sleep(0.5)
+
+            bidding_rule = self.config_params.get("bidder").get("bidding_rule")
+
+            self.logger.info("Creating experiment model for db")
+            experiment = ExperimentModel.create_new(self.experiment_name, self.approach, bidding_rule, dataset, self.new_run)
+            self.logger.info("Experiment: %s \n id: %s \n Approach: %s \n Bidding rule %s \n "
+                             "Dataset: %s",
+                             experiment.name,
+                             experiment.run_id,
+                             experiment.approach,
+                             experiment.bidding_rule,
+                             experiment.dataset)
+            allocate.terminate()
+
+        except (KeyboardInterrupt, SystemExit):
+            print('Task request test interrupted; exiting')
+            allocate.terminate()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('experiment', type=str, action='store', help='Experiment_name')
+    parser.add_argument('approach', type=str, action='store', help='Approach name')
+    parser.add_argument('--file', type=str, action='store', help='Path to the config file')
+    parser.add_argument('--new_run', type=bool, action='store', default=True,
+                        help='If True a new run is added if False last run ' 'is repeated')
+    args = parser.parse_args()
+
+    config_params_ = get_config_params(args.file, experiment=args.experiment, approach=args.approach)
+
+    robot_poses_module = config_params_.get("robot_poses_module")
+    robot_poses_file = config_params_.get("robot_poses")
+    robot_poses_ = load_yaml_file_from_module(robot_poses_module, robot_poses_file + ".yaml")
+
+    run = Experiment(config_params_, robot_poses_, args.new_run)
+    run.start()

--- a/experiments/results/generator.py
+++ b/experiments/results/generator.py
@@ -30,11 +30,11 @@ class ExecutionTimes(AsDictMixin):
 
 
 class TaskPerformanceMetrics(AsDictMixin):
-    def __init__(self, task_id, status, delayed, execution_times):
+    def __init__(self, task_id, status, delayed, **kwargs):
         self.task_id = task_id
         self.status = status
         self.delayed = delayed
-        self.execution_times = execution_times
+        self.execution_times = kwargs.get("execution_times")
         self.allocation_time = None
         self.n_re_allocation_attempts = None
         self.n_re_allocations = None
@@ -72,6 +72,7 @@ class RobotPerformanceMetrics(AsDictMixin):
     def get_metrics(self, run_info, n_allocated_tasks):
         robot_performance = [p for p in run_info.robots_performance if p.robot_id == self.robot_id].pop()
         robot_tasks = robot_performance.allocated_tasks
+        print("Robot id: ", self.robot_id)
 
         self.tasks_performance_metrics = self.get_tasks_performance_metrics(robot_tasks, run_info)
         self.time_distribution = self.get_time_distribution(robot_performance)
@@ -86,9 +87,13 @@ class RobotPerformanceMetrics(AsDictMixin):
             if task_id in robot_tasks:
                 status = dict_repr.get('status')
                 delayed = dict_repr.get('delayed')
-                execution_times = self.get_execution_times(task_status)
 
-                task_performance_metrics = TaskPerformanceMetrics(task_id, status, delayed, execution_times)
+                if status == TaskStatusConst.COMPLETED:
+                    execution_times = self.get_execution_times(task_status)
+                    task_performance_metrics = TaskPerformanceMetrics(task_id, status, delayed, execution_times=execution_times)
+                else:
+                    task_performance_metrics = TaskPerformanceMetrics(task_id, status, delayed)
+
                 task_performance = [p for p in run_info.tasks_performance if p.task_id == task_id].pop()
                 task_performance_metrics.get_metrics(task_performance)
                 tasks_performance_metrics.append(task_performance_metrics)

--- a/experiments/results/non_intentional_delays/tessi-srea-corrective-re-allocate/completion_time/overlapping_loose_1.yaml
+++ b/experiments/results/non_intentional_delays/tessi-srea-corrective-re-allocate/completion_time/overlapping_loose_1.yaml
@@ -1,0 +1,366 @@
+approach: tessi-srea-corrective-re-allocate
+bidding_rule: completion_time
+dataset_name: overlapping_loose_1
+n_tasks: 25
+name: non_intentional_delays
+runs:
+  2:
+    performance_metrics:
+      finish_time: '2020-01-23T09:54:26'
+      fleet_performance_metrics:
+        aborted_tasks: []
+        allocated_tasks:
+        - c176452e-b3ac-424e-84eb-9ee33997b7a5
+        - 2804d0e2-db23-4473-9971-b24dff68575b
+        - ee2cd603-22b7-4e1e-bacd-041c8a887c30
+        - 2ebaa46d-122a-4900-b118-b254250c0f9c
+        - 05431110-a9df-4d20-88db-f1385e8211ad
+        - cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+        - b6a42baa-4337-4f31-b587-09f9da08ae42
+        - 12e1cc80-a98e-4bbb-8932-bb31468bbcc2
+        - d9d4ae16-cff9-45bf-9828-394f9c86e230
+        - b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+        - d171e3b7-883c-4c9c-9295-77c74f391b52
+        - a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+        - eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+        - a42f46af-2281-4c61-8fad-5af558850d11
+        - 722e4099-8e2f-4d94-853f-5e2427ddceaa
+        - fb419558-d29c-4e0c-9252-4946e447a41e
+        - 444a5f09-4522-4a0d-b109-98214428f8f2
+        - 38cbaf9b-4e98-4356-97e2-30a541354203
+        - 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+        - 66552292-781a-407a-a349-16bb403a47d2
+        - 89af4aeb-5513-48d5-8905-066a53a275ff
+        - c8f2b7d3-7e3f-4fe0-a01a-08b8b6015af8
+        - 624b3a05-7f0d-43d0-8452-22f0d08305ed
+        - d8e68116-b00b-464a-afb5-6f7e0082dec1
+        - 6e8e4695-4775-453f-a280-e6295dd344d4
+        biggest_load: 20.0
+        completed_tasks:
+        - c176452e-b3ac-424e-84eb-9ee33997b7a5
+        - 2804d0e2-db23-4473-9971-b24dff68575b
+        - ee2cd603-22b7-4e1e-bacd-041c8a887c30
+        - 2ebaa46d-122a-4900-b118-b254250c0f9c
+        - 05431110-a9df-4d20-88db-f1385e8211ad
+        - cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+        - b6a42baa-4337-4f31-b587-09f9da08ae42
+        - 12e1cc80-a98e-4bbb-8932-bb31468bbcc2
+        - d9d4ae16-cff9-45bf-9828-394f9c86e230
+        - b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+        - d171e3b7-883c-4c9c-9295-77c74f391b52
+        - a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+        - eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+        - a42f46af-2281-4c61-8fad-5af558850d11
+        - 722e4099-8e2f-4d94-853f-5e2427ddceaa
+        - fb419558-d29c-4e0c-9252-4946e447a41e
+        - 444a5f09-4522-4a0d-b109-98214428f8f2
+        - 38cbaf9b-4e98-4356-97e2-30a541354203
+        - 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+        - 66552292-781a-407a-a349-16bb403a47d2
+        - 89af4aeb-5513-48d5-8905-066a53a275ff
+        - c8f2b7d3-7e3f-4fe0-a01a-08b8b6015af8
+        - 624b3a05-7f0d-43d0-8452-22f0d08305ed
+        - d8e68116-b00b-464a-afb5-6f7e0082dec1
+        - 6e8e4695-4775-453f-a280-e6295dd344d4
+        delayed_tasks: []
+        robots_performance_metrics:
+        - robot_id: robot_001
+          tasks_performance_metrics:
+          - allocation_time: 22.760703086853027
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:05:11'
+              pickup_time: '2020-01-23T09:05:08'
+              start_time: '2020-01-23T09:02:51'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 2804d0e2-db23-4473-9971-b24dff68575b
+          - allocation_time: 24.402960777282715
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:16:19'
+              pickup_time: '2020-01-23T09:15:56'
+              start_time: '2020-01-23T09:15:14'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: b6a42baa-4337-4f31-b587-09f9da08ae42
+          - allocation_time: 23.744192838668823
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:27:50'
+              pickup_time: '2020-01-23T09:26:48'
+              start_time: '2020-01-23T09:26:20'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+          - allocation_time: 18.872135162353516
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:39:31'
+              pickup_time: '2020-01-23T09:38:57'
+              start_time: '2020-01-23T09:36:28'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+          - allocation_time: 10.514419317245483
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:51:08'
+              pickup_time: '2020-01-23T09:50:08'
+              start_time: '2020-01-23T09:49:34'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 624b3a05-7f0d-43d0-8452-22f0d08305ed
+          time_distribution:
+            idle_time: 0.0
+            total_time: 2897.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        - robot_id: robot_002
+          tasks_performance_metrics:
+          - allocation_time: 17.444424152374268
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:05:05'
+              pickup_time: '2020-01-23T09:05:00'
+              start_time: '2020-01-23T09:05:00'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: c176452e-b3ac-424e-84eb-9ee33997b7a5
+          - allocation_time: 20.52330493927002
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:16:08'
+              pickup_time: '2020-01-23T09:15:45'
+              start_time: '2020-01-23T09:13:37'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+          - allocation_time: 20.10209631919861
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:27:04'
+              pickup_time: '2020-01-23T09:26:25'
+              start_time: '2020-01-23T09:26:01'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d171e3b7-883c-4c9c-9295-77c74f391b52
+          - allocation_time: 17.100945711135864
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:38:26'
+              pickup_time: '2020-01-23T09:37:28'
+              start_time: '2020-01-23T09:35:03'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: fb419558-d29c-4e0c-9252-4946e447a41e
+          - allocation_time: 10.785384178161621
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:50:44'
+              pickup_time: '2020-01-23T09:49:46'
+              start_time: '2020-01-23T09:47:48'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 89af4aeb-5513-48d5-8905-066a53a275ff
+          time_distribution:
+            idle_time: 0.0
+            total_time: 2744.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        - robot_id: robot_003
+          tasks_performance_metrics:
+          - allocation_time: 22.171489477157593
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:05:20'
+              pickup_time: '2020-01-23T09:05:14'
+              start_time: '2020-01-23T09:02:55'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 2ebaa46d-122a-4900-b118-b254250c0f9c
+          - allocation_time: 24.1869900226593
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:16:25'
+              pickup_time: '2020-01-23T09:16:11'
+              start_time: '2020-01-23T09:12:49'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 12e1cc80-a98e-4bbb-8932-bb31468bbcc2
+          - allocation_time: 21.309404611587524
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:27:55'
+              pickup_time: '2020-01-23T09:27:22'
+              start_time: '2020-01-23T09:25:58'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: a42f46af-2281-4c61-8fad-5af558850d11
+          - allocation_time: 16.16631817817688
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:39:26'
+              pickup_time: '2020-01-23T09:38:30'
+              start_time: '2020-01-23T09:38:08'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 444a5f09-4522-4a0d-b109-98214428f8f2
+          - allocation_time: 7.199073553085327
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:51:23'
+              pickup_time: '2020-01-23T09:50:05'
+              start_time: '2020-01-23T09:48:28'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d8e68116-b00b-464a-afb5-6f7e0082dec1
+          time_distribution:
+            idle_time: 449.0
+            total_time: 2908.0
+            travel_time: 202.0
+            work_time: 14.0
+          usage: 20.0
+        - robot_id: robot_004
+          tasks_performance_metrics:
+          - allocation_time: 23.40532684326172
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:05:11'
+              pickup_time: '2020-01-23T09:05:05'
+              start_time: '2020-01-23T09:04:20'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: ee2cd603-22b7-4e1e-bacd-041c8a887c30
+          - allocation_time: 25.100269556045532
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:16:26'
+              pickup_time: '2020-01-23T09:15:49'
+              start_time: '2020-01-23T09:11:32'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d9d4ae16-cff9-45bf-9828-394f9c86e230
+          - allocation_time: 25.272862434387207
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:27:25'
+              pickup_time: '2020-01-23T09:26:44'
+              start_time: '2020-01-23T09:23:04'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+          - allocation_time: 20.67799663543701
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:39:28'
+              pickup_time: '2020-01-23T09:38:36'
+              start_time: '2020-01-23T09:35:05'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 38cbaf9b-4e98-4356-97e2-30a541354203
+          - allocation_time: 13.24735403060913
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:50:47'
+              pickup_time: '2020-01-23T09:49:11'
+              start_time: '2020-01-23T09:45:03'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: c8f2b7d3-7e3f-4fe0-a01a-08b8b6015af8
+          time_distribution:
+            idle_time: 733.0
+            total_time: 2787.0
+            travel_time: 468.0
+            work_time: 137.0
+          usage: 20.0
+        - robot_id: robot_005
+          tasks_performance_metrics:
+          - allocation_time: 21.252651929855347
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:05:30'
+              pickup_time: '2020-01-23T09:05:19'
+              start_time: '2020-01-23T08:59:51'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 05431110-a9df-4d20-88db-f1385e8211ad
+          - allocation_time: 19.746800899505615
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:16:40'
+              pickup_time: '2020-01-23T09:16:35'
+              start_time: '2020-01-23T09:15:15'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+          - allocation_time: 17.57404637336731
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:28:05'
+              pickup_time: '2020-01-23T09:27:25'
+              start_time: '2020-01-23T09:26:25'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 722e4099-8e2f-4d94-853f-5e2427ddceaa
+          - allocation_time: 14.061878442764282
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:41:00'
+              pickup_time: '2020-01-23T09:39:22'
+              start_time: '2020-01-23T09:38:00'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 66552292-781a-407a-a349-16bb403a47d2
+          - allocation_time: 3.360100746154785
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:54:26'
+              pickup_time: '2020-01-23T09:52:42'
+              start_time: '2020-01-23T09:51:30'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 6e8e4695-4775-453f-a280-e6295dd344d4
+          time_distribution:
+            idle_time: 0.0
+            total_time: 3275.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        time_distribution:
+          idle_time: 94.98625954198474
+          total_time: 3275.0
+          travel_time: 4.091603053435114
+          work_time: 0.9221374045801527
+        usage: 100.0
+      start_time: '2020-01-23T08:59:51'
+      successful: true
+    run_id: 2
+success_rate: 1.0

--- a/experiments/results/non_intentional_delays/tessi-srea-corrective-re-allocate/completion_time/overlapping_random_1.yaml
+++ b/experiments/results/non_intentional_delays/tessi-srea-corrective-re-allocate/completion_time/overlapping_random_1.yaml
@@ -1,0 +1,366 @@
+approach: tessi-srea-corrective-re-allocate
+bidding_rule: completion_time
+dataset_name: overlapping_random_1
+n_tasks: 25
+name: non_intentional_delays
+runs:
+  3:
+    performance_metrics:
+      finish_time: '2020-01-23T09:39:05'
+      fleet_performance_metrics:
+        aborted_tasks: []
+        allocated_tasks:
+        - c176452e-b3ac-424e-84eb-9ee33997b7a5
+        - 2804d0e2-db23-4473-9971-b24dff68575b
+        - ee2cd603-22b7-4e1e-bacd-041c8a887c30
+        - 2ebaa46d-122a-4900-b118-b254250c0f9c
+        - 05431110-a9df-4d20-88db-f1385e8211ad
+        - b6a42baa-4337-4f31-b587-09f9da08ae42
+        - 12e1cc80-a98e-4bbb-8932-bb31468bbcc2
+        - d9d4ae16-cff9-45bf-9828-394f9c86e230
+        - cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+        - b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+        - d171e3b7-883c-4c9c-9295-77c74f391b52
+        - a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+        - 722e4099-8e2f-4d94-853f-5e2427ddceaa
+        - eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+        - a42f46af-2281-4c61-8fad-5af558850d11
+        - fb419558-d29c-4e0c-9252-4946e447a41e
+        - 38cbaf9b-4e98-4356-97e2-30a541354203
+        - 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+        - 444a5f09-4522-4a0d-b109-98214428f8f2
+        - 66552292-781a-407a-a349-16bb403a47d2
+        - 89af4aeb-5513-48d5-8905-066a53a275ff
+        - d8e68116-b00b-464a-afb5-6f7e0082dec1
+        - c8f2b7d3-7e3f-4fe0-a01a-08b8b6015af8
+        - 624b3a05-7f0d-43d0-8452-22f0d08305ed
+        - 6e8e4695-4775-453f-a280-e6295dd344d4
+        biggest_load: 20.0
+        completed_tasks:
+        - c176452e-b3ac-424e-84eb-9ee33997b7a5
+        - 2804d0e2-db23-4473-9971-b24dff68575b
+        - ee2cd603-22b7-4e1e-bacd-041c8a887c30
+        - 2ebaa46d-122a-4900-b118-b254250c0f9c
+        - 05431110-a9df-4d20-88db-f1385e8211ad
+        - b6a42baa-4337-4f31-b587-09f9da08ae42
+        - 12e1cc80-a98e-4bbb-8932-bb31468bbcc2
+        - d9d4ae16-cff9-45bf-9828-394f9c86e230
+        - cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+        - b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+        - d171e3b7-883c-4c9c-9295-77c74f391b52
+        - a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+        - 722e4099-8e2f-4d94-853f-5e2427ddceaa
+        - eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+        - a42f46af-2281-4c61-8fad-5af558850d11
+        - fb419558-d29c-4e0c-9252-4946e447a41e
+        - 38cbaf9b-4e98-4356-97e2-30a541354203
+        - 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+        - 444a5f09-4522-4a0d-b109-98214428f8f2
+        - 66552292-781a-407a-a349-16bb403a47d2
+        - 89af4aeb-5513-48d5-8905-066a53a275ff
+        - d8e68116-b00b-464a-afb5-6f7e0082dec1
+        - c8f2b7d3-7e3f-4fe0-a01a-08b8b6015af8
+        - 624b3a05-7f0d-43d0-8452-22f0d08305ed
+        - 6e8e4695-4775-453f-a280-e6295dd344d4
+        delayed_tasks: []
+        robots_performance_metrics:
+        - robot_id: robot_001
+          tasks_performance_metrics:
+          - allocation_time: 23.132413148880005
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:01:45'
+              pickup_time: '2020-01-23T09:01:42'
+              start_time: '2020-01-23T08:59:25'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 2804d0e2-db23-4473-9971-b24dff68575b
+          - allocation_time: 24.88103938102722
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:08:10'
+              pickup_time: '2020-01-23T09:07:58'
+              start_time: '2020-01-23T09:06:13'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 12e1cc80-a98e-4bbb-8932-bb31468bbcc2
+          - allocation_time: 22.85098624229431
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:17:49'
+              pickup_time: '2020-01-23T09:17:13'
+              start_time: '2020-01-23T09:15:45'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 722e4099-8e2f-4d94-853f-5e2427ddceaa
+          - allocation_time: 17.419040203094482
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:25:27'
+              pickup_time: '2020-01-23T09:24:35'
+              start_time: '2020-01-23T09:24:14'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 444a5f09-4522-4a0d-b109-98214428f8f2
+          - allocation_time: 8.244012594223022
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:35:17'
+              pickup_time: '2020-01-23T09:34:19'
+              start_time: '2020-01-23T09:34:19'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 624b3a05-7f0d-43d0-8452-22f0d08305ed
+          time_distribution:
+            idle_time: 0.0
+            total_time: 2152.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        - robot_id: robot_002
+          tasks_performance_metrics:
+          - allocation_time: 17.176478385925293
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:01:10'
+              pickup_time: '2020-01-23T09:01:04'
+              start_time: '2020-01-23T09:01:04'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: c176452e-b3ac-424e-84eb-9ee33997b7a5
+          - allocation_time: 19.571510076522827
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:07:13'
+              pickup_time: '2020-01-23T09:06:49'
+              start_time: '2020-01-23T09:06:13'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: b6a42baa-4337-4f31-b587-09f9da08ae42
+          - allocation_time: 20.274963855743408
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:18:00'
+              pickup_time: '2020-01-23T09:17:30'
+              start_time: '2020-01-23T09:16:36'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: a42f46af-2281-4c61-8fad-5af558850d11
+          - allocation_time: 14.625272750854492
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:24:07'
+              pickup_time: '2020-01-23T09:23:14'
+              start_time: '2020-01-23T09:21:22'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 38cbaf9b-4e98-4356-97e2-30a541354203
+          - allocation_time: 10.570876359939575
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:30:56'
+              pickup_time: '2020-01-23T09:29:55'
+              start_time: '2020-01-23T09:28:17'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 89af4aeb-5513-48d5-8905-066a53a275ff
+          time_distribution:
+            idle_time: 0.0
+            total_time: 1792.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        - robot_id: robot_003
+          tasks_performance_metrics:
+          - allocation_time: 24.3874192237854
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:03:39'
+              pickup_time: '2020-01-23T09:03:29'
+              start_time: '2020-01-23T09:00:46'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 05431110-a9df-4d20-88db-f1385e8211ad
+          - allocation_time: 21.52977752685547
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:10:39'
+              pickup_time: '2020-01-23T09:10:33'
+              start_time: '2020-01-23T09:09:23'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+          - allocation_time: 16.969151973724365
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:17:59'
+              pickup_time: '2020-01-23T09:16:57'
+              start_time: '2020-01-23T09:16:27'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+          - allocation_time: 12.713566780090332
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:29:20'
+              pickup_time: '2020-01-23T09:27:41'
+              start_time: '2020-01-23T09:26:37'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 66552292-781a-407a-a349-16bb403a47d2
+          - allocation_time: 3.5130250453948975
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:39:05'
+              pickup_time: '2020-01-23T09:37:19'
+              start_time: '2020-01-23T09:36:07'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 6e8e4695-4775-453f-a280-e6295dd344d4
+          time_distribution:
+            idle_time: 0.0
+            total_time: 2299.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        - robot_id: robot_004
+          tasks_performance_metrics:
+          - allocation_time: 24.305314302444458
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:03:06'
+              pickup_time: '2020-01-23T09:03:02'
+              start_time: '2020-01-23T09:02:19'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: ee2cd603-22b7-4e1e-bacd-041c8a887c30
+          - allocation_time: 24.20217752456665
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:10:10'
+              pickup_time: '2020-01-23T09:09:30'
+              start_time: '2020-01-23T09:05:22'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d9d4ae16-cff9-45bf-9828-394f9c86e230
+          - allocation_time: 21.33071255683899
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:15:51'
+              pickup_time: '2020-01-23T09:15:10'
+              start_time: '2020-01-23T09:13:58'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d171e3b7-883c-4c9c-9295-77c74f391b52
+          - allocation_time: 18.23439884185791
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:23:21'
+              pickup_time: '2020-01-23T09:22:22'
+              start_time: '2020-01-23T09:19:48'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: fb419558-d29c-4e0c-9252-4946e447a41e
+          - allocation_time: 8.8844633102417
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:33:26'
+              pickup_time: '2020-01-23T09:32:09'
+              start_time: '2020-01-23T09:28:23'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d8e68116-b00b-464a-afb5-6f7e0082dec1
+          time_distribution:
+            idle_time: 0.0
+            total_time: 1867.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        - robot_id: robot_005
+          tasks_performance_metrics:
+          - allocation_time: 19.904436826705933
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:03:31'
+              pickup_time: '2020-01-23T09:03:26'
+              start_time: '2020-01-23T08:58:19'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 2ebaa46d-122a-4900-b118-b254250c0f9c
+          - allocation_time: 22.85604166984558
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:10:25'
+              pickup_time: '2020-01-23T09:10:04'
+              start_time: '2020-01-23T09:09:41'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+          - allocation_time: 20.662608861923218
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:16:30'
+              pickup_time: '2020-01-23T09:15:49'
+              start_time: '2020-01-23T09:12:30'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+          - allocation_time: 15.328224897384644
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:24:43'
+              pickup_time: '2020-01-23T09:24:07'
+              start_time: '2020-01-23T09:22:55'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+          - allocation_time: 7.4860522747039795
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:34:59'
+              pickup_time: '2020-01-23T09:33:25'
+              start_time: '2020-01-23T09:30:05'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: c8f2b7d3-7e3f-4fe0-a01a-08b8b6015af8
+          time_distribution:
+            idle_time: 0.0
+            total_time: 2200.0
+            travel_time: 0.0
+            work_time: 0.0
+          usage: 20.0
+        time_distribution:
+          idle_time: 100.0
+          total_time: 2446.0
+          travel_time: 0.0
+          work_time: 0.0
+        usage: 100.0
+      start_time: '2020-01-23T08:58:19'
+      successful: true
+    run_id: 3
+success_rate: 1.0

--- a/experiments/results/non_intentional_delays/tessi-srea-corrective-re-allocate/completion_time/overlapping_tight_1.yaml
+++ b/experiments/results/non_intentional_delays/tessi-srea-corrective-re-allocate/completion_time/overlapping_tight_1.yaml
@@ -1,0 +1,340 @@
+approach: tessi-srea-corrective-re-allocate
+bidding_rule: completion_time
+dataset_name: overlapping_tight_1
+n_tasks: 25
+name: non_intentional_delays
+runs:
+  1:
+    performance_metrics:
+      finish_time: '2020-01-23T09:18:15'
+      fleet_performance_metrics:
+        aborted_tasks:
+        - 12e1cc80-a98e-4bbb-8932-bb31468bbcc2
+        - a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+        - c8f2b7d3-7e3f-4fe0-a01a-08b8b6015af8
+        allocated_tasks:
+        - ee2cd603-22b7-4e1e-bacd-041c8a887c30
+        - c176452e-b3ac-424e-84eb-9ee33997b7a5
+        - 2804d0e2-db23-4473-9971-b24dff68575b
+        - 2ebaa46d-122a-4900-b118-b254250c0f9c
+        - 05431110-a9df-4d20-88db-f1385e8211ad
+        - cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+        - d9d4ae16-cff9-45bf-9828-394f9c86e230
+        - b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+        - b6a42baa-4337-4f31-b587-09f9da08ae42
+        - d171e3b7-883c-4c9c-9295-77c74f391b52
+        - eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+        - 722e4099-8e2f-4d94-853f-5e2427ddceaa
+        - a42f46af-2281-4c61-8fad-5af558850d11
+        - fb419558-d29c-4e0c-9252-4946e447a41e
+        - 444a5f09-4522-4a0d-b109-98214428f8f2
+        - 38cbaf9b-4e98-4356-97e2-30a541354203
+        - 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+        - 66552292-781a-407a-a349-16bb403a47d2
+        - 89af4aeb-5513-48d5-8905-066a53a275ff
+        - 624b3a05-7f0d-43d0-8452-22f0d08305ed
+        - d8e68116-b00b-464a-afb5-6f7e0082dec1
+        - 6e8e4695-4775-453f-a280-e6295dd344d4
+        biggest_load: 22.727272727272727
+        completed_tasks:
+        - ee2cd603-22b7-4e1e-bacd-041c8a887c30
+        - c176452e-b3ac-424e-84eb-9ee33997b7a5
+        - 2804d0e2-db23-4473-9971-b24dff68575b
+        - 2ebaa46d-122a-4900-b118-b254250c0f9c
+        - 05431110-a9df-4d20-88db-f1385e8211ad
+        - cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+        - d9d4ae16-cff9-45bf-9828-394f9c86e230
+        - b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+        - b6a42baa-4337-4f31-b587-09f9da08ae42
+        - d171e3b7-883c-4c9c-9295-77c74f391b52
+        - eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+        - 722e4099-8e2f-4d94-853f-5e2427ddceaa
+        - a42f46af-2281-4c61-8fad-5af558850d11
+        - fb419558-d29c-4e0c-9252-4946e447a41e
+        - 444a5f09-4522-4a0d-b109-98214428f8f2
+        - 38cbaf9b-4e98-4356-97e2-30a541354203
+        - 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+        - 66552292-781a-407a-a349-16bb403a47d2
+        - 89af4aeb-5513-48d5-8905-066a53a275ff
+        - 624b3a05-7f0d-43d0-8452-22f0d08305ed
+        - d8e68116-b00b-464a-afb5-6f7e0082dec1
+        - 6e8e4695-4775-453f-a280-e6295dd344d4
+        delayed_tasks: []
+        robots_performance_metrics:
+        - robot_id: robot_001
+          tasks_performance_metrics:
+          - allocation_time: 36.71099543571472
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:01:10'
+              pickup_time: '2020-01-23T09:01:07'
+              start_time: '2020-01-23T08:58:51'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 2804d0e2-db23-4473-9971-b24dff68575b
+          - allocation_time: 27.311416625976562
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:04:07'
+              pickup_time: '2020-01-23T09:03:32'
+              start_time: '2020-01-23T09:01:59'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d9d4ae16-cff9-45bf-9828-394f9c86e230
+          - allocation_time: 22.398185968399048
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:08:07'
+              pickup_time: '2020-01-23T09:07:33'
+              start_time: '2020-01-23T09:05:42'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: a42f46af-2281-4c61-8fad-5af558850d11
+          - allocation_time: 23.16091227531433
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:11:20'
+              pickup_time: '2020-01-23T09:10:30'
+              start_time: '2020-01-23T09:10:08'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 444a5f09-4522-4a0d-b109-98214428f8f2
+          - allocation_time: 13.027783155441284
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:18:15'
+              pickup_time: '2020-01-23T09:16:29'
+              start_time: '2020-01-23T09:14:22'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 6e8e4695-4775-453f-a280-e6295dd344d4
+          time_distribution:
+            idle_time: 447.0
+            total_time: 1164.0
+            travel_time: 489.0
+            work_time: 228.0
+          usage: 22.727272727272727
+        - robot_id: robot_002
+          tasks_performance_metrics:
+          - allocation_time: 28.387136459350586
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:01:06'
+              pickup_time: '2020-01-23T09:01:00'
+              start_time: '2020-01-23T09:01:00'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: c176452e-b3ac-424e-84eb-9ee33997b7a5
+          - allocation_time: 20.759260416030884
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:04:00'
+              pickup_time: '2020-01-23T09:03:37'
+              start_time: '2020-01-23T09:01:37'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: cdc0b1bc-caa9-4bbe-a075-f7f58fb38a26
+          - allocation_time: 20.098745584487915
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:07:50'
+              pickup_time: '2020-01-23T09:06:46'
+              start_time: '2020-01-23T09:06:33'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: eb3997ea-ba87-4153-bcb7-2ebddb07df1a
+          - allocation_time: 17.512672185897827
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:11:32'
+              pickup_time: '2020-01-23T09:10:53'
+              start_time: '2020-01-23T09:08:28'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 534ac3a2-069b-4f86-a54b-1f8e52b524e5
+          - allocation_time: 12.088982820510864
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:15:20'
+              pickup_time: '2020-01-23T09:14:04'
+              start_time: '2020-01-23T09:13:00'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d8e68116-b00b-464a-afb5-6f7e0082dec1
+          time_distribution:
+            idle_time: 310.0
+            total_time: 860.0
+            travel_time: 342.0
+            work_time: 208.0
+          usage: 22.727272727272727
+        - robot_id: robot_003
+          tasks_performance_metrics:
+          - allocation_time: 35.509170055389404
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:01:19'
+              pickup_time: '2020-01-23T09:01:13'
+              start_time: '2020-01-23T08:58:55'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 2ebaa46d-122a-4900-b118-b254250c0f9c
+          - allocation_time: 21.77713656425476
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:04:26'
+              pickup_time: '2020-01-23T09:04:21'
+              start_time: '2020-01-23T09:03:47'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: b5c49aee-dc2d-4621-aa8e-3da50c566dc0
+          - allocation_time: 22.344242334365845
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:08:06'
+              pickup_time: '2020-01-23T09:07:25'
+              start_time: '2020-01-23T09:06:25'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 722e4099-8e2f-4d94-853f-5e2427ddceaa
+          - allocation_time: 17.986254453659058
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:13:04'
+              pickup_time: '2020-01-23T09:11:20'
+              start_time: '2020-01-23T09:10:00'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 66552292-781a-407a-a349-16bb403a47d2
+          time_distribution:
+            idle_time: 381.0
+            total_time: 849.0
+            travel_time: 312.0
+            work_time: 156.0
+          usage: 18.181818181818183
+        - robot_id: robot_004
+          tasks_performance_metrics:
+          - allocation_time: 23.10211157798767
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:01:05'
+              pickup_time: '2020-01-23T09:01:00'
+              start_time: '2020-01-23T09:00:18'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: ee2cd603-22b7-4e1e-bacd-041c8a887c30
+          - allocation_time: 9.168405055999756
+            delayed: false
+            execution_times: null
+            n_re_allocation_attempts: 1
+            n_re_allocations: 0
+            status: 7
+            task_id: a90a8fc5-9a4b-466e-9c5c-0d8844ddd85e
+          - allocation_time: 29.925466060638428
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:04:46'
+              pickup_time: '2020-01-23T09:04:22'
+              start_time: '2020-01-23T09:01:06'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: b6a42baa-4337-4f31-b587-09f9da08ae42
+          - allocation_time: 21.484495401382446
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:10:14'
+              pickup_time: '2020-01-23T09:09:19'
+              start_time: '2020-01-23T09:09:17'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: fb419558-d29c-4e0c-9252-4946e447a41e
+          - allocation_time: 14.765290975570679
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:14:58'
+              pickup_time: '2020-01-23T09:13:56'
+              start_time: '2020-01-23T09:11:48'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 89af4aeb-5513-48d5-8905-066a53a275ff
+          time_distribution:
+            idle_time: 366.0
+            total_time: 880.0
+            travel_time: 368.0
+            work_time: 146.0
+          usage: 22.727272727272727
+        - robot_id: robot_005
+          tasks_performance_metrics:
+          - allocation_time: 23.45266056060791
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:01:30'
+              pickup_time: '2020-01-23T09:01:21'
+              start_time: '2020-01-23T08:55:51'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 05431110-a9df-4d20-88db-f1385e8211ad
+          - allocation_time: 19.959442615509033
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:07:08'
+              pickup_time: '2020-01-23T09:06:29'
+              start_time: '2020-01-23T09:06:23'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: d171e3b7-883c-4c9c-9295-77c74f391b52
+          - allocation_time: 18.087159633636475
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:11:25'
+              pickup_time: '2020-01-23T09:10:30'
+              start_time: '2020-01-23T09:09:17'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 38cbaf9b-4e98-4356-97e2-30a541354203
+          - allocation_time: 15.183419466018677
+            delayed: false
+            execution_times:
+              delivery_time: '2020-01-23T09:15:09'
+              pickup_time: '2020-01-23T09:14:10'
+              start_time: '2020-01-23T09:12:37'
+            n_re_allocation_attempts: 0
+            n_re_allocations: 0
+            status: 6
+            task_id: 624b3a05-7f0d-43d0-8452-22f0d08305ed
+          time_distribution:
+            idle_time: 494.0
+            total_time: 1158.0
+            travel_time: 502.0
+            work_time: 162.0
+          usage: 18.181818181818183
+        time_distribution:
+          idle_time: 56.651785714285715
+          total_time: 1344.0
+          travel_time: 29.955357142857142
+          work_time: 13.392857142857142
+        usage: 100.0
+      start_time: '2020-01-23T08:55:51'
+      successful: false
+    run_id: 1
+success_rate: 0.0

--- a/experiments/run.py
+++ b/experiments/run.py
@@ -1,80 +1,32 @@
 import argparse
-import logging.config
-import time
+import subprocess
 
-from mrs.allocate import Allocate
+from mrs.config.params import experiment_number, approach_number
 from mrs.config.params import get_config_params
-from experiments.db.models.experiment import Experiment
-from mrs.utils.utils import load_yaml_file_from_module
 
 
-class RunExperiment:
-    def __init__(self, config_params, robot_poses, new_run=True):
-        self.config_params = config_params
-        self.experiment_name = config_params.get("experiment")
-        self.approach = config_params.get("approach")
-        self.robot_poses = robot_poses
-        self.new_run = new_run
+def run(robot_ids, docker_compose_file):
 
-        self.dataset_module = config_params.get("dataset_module")
-        self.datasets = config_params.get("datasets")
+    subprocess.call(["docker-compose", "-f", docker_compose_file, "build", "mrta"])
 
-        self.logger = logging.getLogger('mrs.allocate')
-        logger_config = self.config_params.get('logger')
-        logging.config.dictConfig(logger_config)
+    for robot_id in robot_ids:
+        subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "-d", "robot_proxy_"+ str(robot_id.split("_")[1])])
+        subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "-d", str(robot_id)])
 
-        self.logger.info("Experiment: %s \n Approach: %s \n Dataset Module: %s\n Datasets: %s",
-                         self.experiment_name,
-                         self.approach,
-                         self.dataset_module,
-                         self.datasets)
-
-    def start(self):
-        for dataset in self.datasets:
-            self.logger.info("Running experiment with dataset %s", dataset)
-            self.run(dataset)
-
-    def run(self, dataset):
-        allocate = Allocate(self.config_params, self.robot_poses, self.dataset_module, dataset)
-        try:
-            allocate.start_allocation()
-            while not allocate.terminated:
-                print("Approx current time: ", allocate.simulator_interface.get_current_time())
-                allocate.check_termination_test()
-                time.sleep(0.5)
-
-            bidding_rule = self.config_params.get("bidder").get("bidding_rule")
-
-            self.logger.info("Creating experiment model for db")
-            experiment = Experiment.create_new(self.experiment_name, self.approach, bidding_rule, dataset, self.new_run)
-            self.logger.info("Experiment: %s \n id: %s \n Approach: %s \n Bidding rule %s \n "
-                             "Dataset: %s",
-                             experiment.name,
-                             experiment.run_id,
-                             experiment.approach,
-                             experiment.bidding_rule,
-                             experiment.dataset)
-            allocate.terminate()
-
-        except (KeyboardInterrupt, SystemExit):
-            print('Task request test interrupted; exiting')
-            allocate.terminate()
+    subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "-d", "ccu"])
+    subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "mrta"])
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('experiment', type=str, action='store', help='Experiment_name')
     parser.add_argument('approach', type=str, action='store', help='Approach name')
-    parser.add_argument('--file', type=str, action='store', help='Path to the config file')
-    parser.add_argument('--new_run', type=bool, action='store', default=True,
-                        help='If True a new run is added if False last run ' 'is repeated')
     args = parser.parse_args()
 
-    config_params_ = get_config_params(args.file, experiment=args.experiment, approach=args.approach)
+    docker_compose_file_ = "docker_files/exp-" + experiment_number.get(args.experiment) + \
+                           "-approach-" + approach_number.get(args.approach) + ".yaml"
 
-    robot_poses_module = config_params_.get("robot_poses_module")
-    robot_poses_file = config_params_.get("robot_poses")
-    robot_poses_ = load_yaml_file_from_module(robot_poses_module, robot_poses_file + ".yaml")
+    config_params = get_config_params(experiment=args.experiment)
+    robot_ids_ = config_params.get("fleet")
 
-    run = RunExperiment(config_params_, robot_poses_, args.new_run)
-    run.start()
+    run(robot_ids_, docker_compose_file_)

--- a/mrs/allocation/bidder.py
+++ b/mrs/allocation/bidder.py
@@ -66,7 +66,7 @@ class Bidder:
     def task_announcement_cb(self, msg):
         payload = msg['payload']
         task_announcement = TaskAnnouncement.from_payload(payload)
-        self.logger.debug("Received TASK-ANNOUNCEMENT msg round %s with tasks %s", task_announcement.round_id,
+        self.logger.debug("Received TASK-ANNOUNCEMENT msg round %s with %s tasks", task_announcement.round_id,
                                                                                    len(task_announcement.tasks))
         self.logger.debug("Current stn: %s", self.timetable.stn)
         self.logger.debug("Current dispatchable graph: %s", self.timetable.dispatchable_graph)
@@ -272,6 +272,11 @@ class Bidder:
         smallest_bid = None
 
         for bid in bids:
+            # Do not consider bids for tasks that were frozen after the bid computation
+            task = Task.get_task(bid.task_id)
+            if task.frozen:
+                continue
+
             if smallest_bid is None or\
                     bid < smallest_bid or\
                     (bid == smallest_bid and bid.task_id < smallest_bid.task_id):

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -14,7 +14,7 @@ robot_store:
 
 simulator:
   initial_time: 2020-01-23T08:00:00.000000
-  factor: 0.1
+  factor: 0.2
 
 fleet:
   - robot_001

--- a/mrs/db/models/performance/robot.py
+++ b/mrs/db/models/performance/robot.py
@@ -45,7 +45,7 @@ class RobotPerformance(MongoModel):
         self.save()
 
     def unallocated(self, task_id):
-        self.allocated_tasks.pop(task_id)
+        self.allocated_tasks.remove(task_id)
         self.save()
 
     def update_travel_time(self, travel_time):

--- a/mrs/performance/robot.py
+++ b/mrs/performance/robot.py
@@ -9,12 +9,11 @@ class RobotPerformanceTracker:
         self.processed_tasks = list()
 
     def update_metrics(self, robot_id, tasks_progress):
-        self.logger.debug("Updating performance of robot %s", robot_id)
+        self.logger.critical("Updating performance of robot %s", robot_id)
         robot_performance = RobotPerformance.get_robot_performance(robot_id)
         for task_idx, actions_progress in enumerate(tasks_progress):
             task_id = actions_progress[0].action.task_id
             if task_id not in self.processed_tasks:
-                robot_performance.update_allocated_tasks(task_id)
                 for action_progress in actions_progress:
                     time_ = (action_progress.finish_time - action_progress.start_time).total_seconds()
                     if action_progress.action.type == "ROBOT-TO-PICKUP":
@@ -42,6 +41,11 @@ class RobotPerformanceTracker:
         finish_last_task = tasks_progress[-1][-1].finish_time
         start_fist_task = tasks_progress[0][0].start_time
         return start_fist_task, finish_last_task
+
+    def update_allocated_tasks(self, robot_id, task_id):
+        robot_performance = RobotPerformance.get_robot_performance(robot_id)
+        robot_performance.update_allocated_tasks(task_id)
+        self.logger.debug("Robot %s allocated tasks: %s", robot_id, [task_id for task_id in robot_performance.allocated_tasks])
 
     @staticmethod
     def update_re_allocations(task):

--- a/mrs/performance/tracker.py
+++ b/mrs/performance/tracker.py
@@ -23,6 +23,7 @@ class PerformanceTracker:
         for robot_id in robot_ids:
             timetable = self.timetable_manager.get_timetable(robot_id)
             self.task_performance_tracker.update_allocation_metrics(allocated_task_id, timetable, tasks_to_update)
+            self.robot_performance_tracker.update_allocated_tasks(robot_id, allocated_task_id)
 
     @staticmethod
     def get_tasks_progress(robot_id):

--- a/mrs/tests/datasets/non_overlapping.yaml
+++ b/mrs/tests/datasets/non_overlapping.yaml
@@ -10,7 +10,7 @@ start_time_lower_bound: 1
 start_time_upper_bound: 2
 task_type: task
 tasks:
-  44c8caa6-ddf0-4876-8364-0c5ca8082880:
+  45b34703-eaaf-4063-b3cc-15acb7e850ca:
     delivery_location: C016-1
     earliest_pickup_time: 300
     hard_constraints: true
@@ -32,8 +32,8 @@ tasks:
         - C016-2
         - LC-003
         - C016-1
-    task_id: 44c8caa6-ddf0-4876-8364-0c5ca8082880
-  45b34703-eaaf-4063-b3cc-15acb7e850ca:
+    task_id: 45b34703-eaaf-4063-b3cc-15acb7e850ca
+  44c8caa6-ddf0-4876-8364-0c5ca8082880:
     delivery_location: C016-1
     earliest_pickup_time: 420
     hard_constraints: true
@@ -45,7 +45,7 @@ tasks:
         - C015
         - LC-010
         - C016-1
-    task_id: 45b34703-eaaf-4063-b3cc-15acb7e850ca
+    task_id: 44c8caa6-ddf0-4876-8364-0c5ca8082880
   56f9df3b-5c64-4ab0-88d0-659023f121f2:
     delivery_location: C019
     earliest_pickup_time: 580

--- a/mrs/tests/docker_files/approach-1.yaml
+++ b/mrs/tests/docker_files/approach-1.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-preventive-abort
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-10.yaml
+++ b/mrs/tests/docker_files/approach-10.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-srea-corrective-re-allocate
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-11.yaml
+++ b/mrs/tests/docker_files/approach-11.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-dsc-preventive-abort
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-12.yaml
+++ b/mrs/tests/docker_files/approach-12.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-dsc-preventive-re-allocate
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-13.yaml
+++ b/mrs/tests/docker_files/approach-13.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-dsc-corrective-abort
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-14.yaml
+++ b/mrs/tests/docker_files/approach-14.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-dsc-corrective-re-allocate
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-2.yaml
+++ b/mrs/tests/docker_files/approach-2.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-preventive-re-allocate
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-3.yaml
+++ b/mrs/tests/docker_files/approach-3.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-corrective-abort
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-4.yaml
+++ b/mrs/tests/docker_files/approach-4.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-corrective-re-allocate
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-5.yaml
+++ b/mrs/tests/docker_files/approach-5.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-srea-preventive-abort
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-6.yaml
+++ b/mrs/tests/docker_files/approach-6.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-srea-preventive-re-allocate
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-7.yaml
+++ b/mrs/tests/docker_files/approach-7.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-srea-preventive-re-schedule-abort
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-8.yaml
+++ b/mrs/tests/docker_files/approach-8.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-srea-preventive-re-schedule-re-allocate
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/docker_files/approach-9.yaml
+++ b/mrs/tests/docker_files/approach-9.yaml
@@ -21,7 +21,7 @@ services:
     - 27017:27017
     volumes:
     - /data/db:/data/db
-  mrta_test:
+  mrta:
     build:
       context: ../../..
       dockerfile: Dockerfile
@@ -30,20 +30,7 @@ services:
     - test.py
     - --approach
     - tessi-srea-corrective-abort
-    container_name: mrta-test
-    depends_on:
-    - mongo
-    - ccu
-    - robot_001
-    - robot_proxy_001
-    - robot_002
-    - robot_proxy_002
-    - robot_003
-    - robot_proxy_003
-    - robot_004
-    - robot_proxy_004
-    - robot_005
-    - robot_proxy_005
+    container_name: mrta
     image: ropod-mrs
     network_mode: host
     stdin_open: 'true'

--- a/mrs/tests/run.py
+++ b/mrs/tests/run.py
@@ -1,0 +1,31 @@
+import argparse
+import subprocess
+
+from mrs.config.params import approach_number
+from mrs.config.params import get_config_params
+
+
+def run(robot_ids, docker_compose_file):
+
+    subprocess.call(["docker-compose", "-f", docker_compose_file, "build", "mrta"])
+
+    for robot_id in robot_ids:
+        subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "-d", "robot_proxy_"+ str(robot_id.split("_")[1])])
+        subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "-d", str(robot_id)])
+
+    subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "-d", "ccu"])
+    subprocess.call(["docker-compose", "-f", docker_compose_file, "up", "mrta"])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--file', type=str, action='store', help='Path to the config file')
+    parser.add_argument('approach', type=str, action='store', help='Approach name')
+    args = parser.parse_args()
+
+    docker_compose_file_ = "docker_files/approach-" + approach_number.get(args.approach) + ".yaml"
+
+    config_params = get_config_params(args.file, approach=args.approach)
+    robot_ids_ = config_params.get("fleet")
+
+    run(robot_ids_, docker_compose_file_)

--- a/mrs/utils/docker.py
+++ b/mrs/utils/docker.py
@@ -125,7 +125,7 @@ class TestComposeFileGenerator(ComposeFileGenerator):
 
         self.test_service = {"build": {"context": "../../..",
                                        "dockerfile": "Dockerfile"},
-                             "container_name": "mrta-test",
+                             "container_name": "mrta",
                              "working_dir": "/mrta/mrs/tests/",
                              }
 
@@ -136,15 +136,9 @@ class TestComposeFileGenerator(ComposeFileGenerator):
             command.append("--" + arg_name)
             command.append(value)
 
-        depends_on = ["mongo", "ccu"]
-        for robot_id in self.robot_ids:
-            depends_on.append(robot_id)
-            depends_on.append("robot_proxy_" + robot_id.split('_')[1])
-
-        test_service["mrta_test"] = copy.deepcopy(self.component_template)
-        test_service["mrta_test"].update(command=command,
-                                         depends_on=depends_on,
-                                         **self.test_service)
+        test_service["mrta"] = copy.deepcopy(self.component_template)
+        test_service["mrta"].pop("depends_on")
+        test_service["mrta"].update(command=command, **self.test_service)
         return test_service
 
     def generate_services(self):
@@ -161,25 +155,19 @@ class ExperimentComposeFileGenerator(ComposeFileGenerator):
 
         self.experiment_service = {"build": {"context": "../../",
                                              "dockerfile": "Dockerfile"},
-                                   "container_name": "mrta-experiment",
+                                   "container_name": "mrta",
                                    "working_dir": "/mrta/experiments/",
                                    }
 
     def generate_experiment_service(self):
         experiment_service = dict()
-        command = ["python3", "run.py"]
+        command = ["python3", "experiment.py"]
         for arg in self.experiment_args:
             command.append(arg)
 
-        depends_on = ["mongo", "ccu"]
-        for robot_id in self.robot_ids:
-            depends_on.append(robot_id)
-            depends_on.append("robot_proxy_" + robot_id.split('_')[1])
-
-        experiment_service["mrta_experiment"] = copy.deepcopy(self.component_template)
-        experiment_service["mrta_experiment"].update(command=command,
-                                                     depends_on=depends_on,
-                                                     **self.experiment_service)
+        experiment_service["mrta"] = copy.deepcopy(self.component_template)
+        experiment_service["mrta"].pop("depends_on")
+        experiment_service["mrta"].update(command=command, **self.experiment_service)
         return experiment_service
 
     def generate_services(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pymongo
 importlib_resources
 simpy
 PyYAML
-git+https://github.com/anenriquez/fmlib.git@feature/action-progress-time
+git+https://github.com/ropod-project/fmlib.git@develop
 git+https://github.com/anenriquez/mrta_stn.git@develop#egg=stn


### PR DESCRIPTION
- Add script to bring up containers in order:
robot_proxies
robots
ccu
mrta
With docker-compose file, the containers started with a different order, which caused issues in the allocation process. A robot would take unexpectedly long calculating its bids with no apparent reason. 
- Dockerfile: Set time zone to CET
- config: Set simulator factor to 0.2. A slower simulator factor allows robots to allocate task before starting execution
- requirements: Use ropod-project fmlib develop
- experiments: Get execution time of completed tasks
- bid: Do not consider bids for tasks that were frozen after the bid computation
- robot_performance: Update allocated tasks